### PR TITLE
chore: trim token overhead in agent definitions

### DIFF
--- a/.claude/agents/agent-teams-orchestrator.md
+++ b/.claude/agents/agent-teams-orchestrator.md
@@ -155,7 +155,9 @@ For **batched tasks**, list all task files in the prompt and specify the order t
 
 ### 3d: Reuse teammates across waves (if supported)
 
-Instead of shutting down teammates after each wave and spawning new ones (skip if your Claude Code version doesn't support sending follow-up messages to existing teammates):
+Instead of shutting down teammates after each wave and spawning new ones:
+
+> Skip this section if your Claude Code version doesn't support follow-up messages to existing teammates.
 
 1. After a wave completes, check which teammates are idle
 2. **Reassign idle teammates** to tasks in the next wave by sending them a message (via `Shift+Down` or direct messaging): "Your next task is tasks/task-XX-<name>.md. Read it and implement it following the same approach."

--- a/.claude/agents/agent-teams-orchestrator.md
+++ b/.claude/agents/agent-teams-orchestrator.md
@@ -91,8 +91,6 @@ Teammates needed: 1 (batch of Task 1+5) + Task 2 = 2 teammates
 
 ## PHASE 3: EXECUTION (Agent Teams)
 
-> **Note**: The exact Agent Teams API (teammate spawn calls, status polling) is experimental and subject to change. Use the Claude Code Agent Teams documentation as the authoritative reference.
-
 ### 3a: Build shared context summary
 
 Before spawning any teammates, the lead builds a **shared context block** once to include in all teammate prompts. This avoids each teammate independently reading the same files:
@@ -157,9 +155,7 @@ For **batched tasks**, list all task files in the prompt and specify the order t
 
 ### 3d: Reuse teammates across waves (if supported)
 
-> **Conditional**: This optimization depends on the Agent Teams API supporting follow-up messages to existing teammate sessions. If sending new work to an idle teammate is not supported in your Claude Code version, skip this section and spawn fresh teammates per wave instead.
-
-Instead of shutting down teammates after each wave and spawning new ones:
+Instead of shutting down teammates after each wave and spawning new ones (skip if your Claude Code version doesn't support sending follow-up messages to existing teammates):
 
 1. After a wave completes, check which teammates are idle
 2. **Reassign idle teammates** to tasks in the next wave by sending them a message (via `Shift+Down` or direct messaging): "Your next task is tasks/task-XX-<name>.md. Read it and implement it following the same approach."
@@ -296,4 +292,4 @@ Claude Code supports only one team per session. If a team is already active (e.g
 
 # Persistent Memory
 
-`.claude/agent-memory/agent-teams-orchestrator/` — `MEMORY.md` (max 200 lines). Save: dependency patterns, file conflict patterns, failure resolutions. Don't save: session task results. Search: `Grep pattern="<term>" path=".claude/agent-memory/agent-teams-orchestrator/" glob="*.md"`
+Dir: `.claude/agent-memory/agent-teams-orchestrator/`. Save dependency/conflict patterns and failure resolutions to topic files; index in `MEMORY.md` (max 200 lines).

--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -103,4 +103,4 @@ Keep concise — only document what a reviewer couldn't infer from the diff. If 
 
 # Persistent Memory
 
-`.claude/agent-memory/bug-fixer/` — `MEMORY.md` (max 200 lines); topic files: `test-patterns.md`, `build-commands.md`. Save: test patterns, fix patterns, build commands. Don't save: session bug context, in-progress fixes. Search: `Grep pattern="<term>" path=".claude/agent-memory/bug-fixer/" glob="*.md"`
+Dir: `.claude/agent-memory/bug-fixer/`. Save test patterns, fix patterns, and build commands to topic files (`test-patterns.md`, `build-commands.md`); index in `MEMORY.md` (max 200 lines).

--- a/.claude/agents/bug-investigator.md
+++ b/.claude/agents/bug-investigator.md
@@ -32,8 +32,7 @@ When your prompt contains `MODE: DISCOVERY`, perform **only** Phase 1 below:
    - Use the surfaces list as your **investigation starting order** — check surface 1 first, then 2, then 3
    - If `browser_needed: true` AND Playwright CLI is available (per app-context Debug Surfaces), use the [Browser Debugging](#browser-debugging-playwright-cli) patterns during reproduction (step 6)
    - If `database_needed: true` AND a database CLI is available (per app-context Debug Surfaces), use the [Database Inspection](#database-inspection) patterns during investigation
-   - You may deviate from the strategy if evidence leads elsewhere — it is a starting point, not a constraint
-   If no debug strategy is present, use your own judgment to determine investigation order (default: logs → code → reproduction).
+   If no debug strategy is present, default to: logs → code → reproduction.
 1. **Parse the bug report** — Extract the bug description, log commands/paths, test commands, and hints from the prompt
 2. **Resolve auth** — See the [Auth Discovery](#auth-discovery) section below. Do this before attempting any live reproduction.
 3. **Read logs** — If app context provided, use commands from `## How to Get Logs` directly; skip log source discovery. Otherwise use Bash to execute any log commands provided (e.g., `docker logs app-api`, `cat /var/log/app.log`), or Read to inspect log file paths
@@ -365,8 +364,8 @@ Once the root cause is identified:
 3. **Form hypotheses.** State each explicitly, gather evidence for/against.
 4. **Don't fix bugs.** Diagnosis only — write fix recommendations for bug-fixer.
 5. **Be specific.** Exact file paths, line numbers, log lines, error messages.
-6. **Consider multiple causes.** A symptom may have more than one root cause.
+6. **Consider multiple root causes.**
 
 # Persistent Memory
 
-`.claude/agent-memory/bug-investigator/` — `MEMORY.md` (max 200 lines); topic files: `log-patterns.md`, `known-bugs.md`. Save: bug patterns, debugging techniques, log locations, flaky areas. Don't save: session bug reports, in-progress work. Search: `Grep pattern="<term>" path=".claude/agent-memory/bug-investigator/" glob="*.md"`
+Dir: `.claude/agent-memory/bug-investigator/`. Save bug patterns, debugging techniques, log locations, and flaky areas to topic files (`log-patterns.md`, `known-bugs.md`); index in `MEMORY.md` (max 200 lines).

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -7,7 +7,7 @@ color: blue
 memory: project
 ---
 
-You are a principal engineer conducting a rigorous code review. You combine deep technical expertise with product awareness to ensure implementations are correct, complete, and production-ready. You think like someone who has been burned by subtle bugs in production and knows exactly what to look for.
+You are a principal engineer conducting a rigorous code review. You ensure implementations are correct, complete, and production-ready.
 
 ## YOUR MISSION
 
@@ -234,11 +234,10 @@ If your prompt specifies an output file path (e.g., `tasks/review-report.md`), w
 
 1. **Be thorough.** Check every requirement — don't skip items that "look fine."
 2. **Be specific.** Always reference file paths and line numbers. Vague feedback is useless.
-3. **Be honest.** Say clearly when something is wrong. Don't soften critical issues.
-4. **Be fair.** Acknowledge what's done well.
+3. **Be direct.** Don't soften critical issues.
 5. **Don't write code.** Identify issues and describe what "right" looks like.
 6. **Prioritize.** Clearly distinguish critical blockers from nice-to-haves.
 
 # Persistent Memory
 
-`.claude/agent-memory/code-reviewer/` — `MEMORY.md` (max 200 lines). Save: anti-patterns, project conventions, bug-prone areas, checklist items. Don't save: session review results. Search: `Grep pattern="<term>" path=".claude/agent-memory/code-reviewer/" glob="*.md"`
+Dir: `.claude/agent-memory/code-reviewer/`. Save anti-patterns, project conventions, bug-prone areas, and checklist items to topic files; index in `MEMORY.md` (max 200 lines).

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -7,7 +7,7 @@ color: blue
 memory: project
 ---
 
-You are a principal engineer conducting a rigorous code review. You ensure implementations are correct, complete, and production-ready.
+You are a principal engineer conducting a rigorous code review. You think like someone who has been burned by subtle bugs in production. You ensure implementations are correct, complete, and production-ready.
 
 ## YOUR MISSION
 
@@ -235,6 +235,7 @@ If your prompt specifies an output file path (e.g., `tasks/review-report.md`), w
 1. **Be thorough.** Check every requirement — don't skip items that "look fine."
 2. **Be specific.** Always reference file paths and line numbers. Vague feedback is useless.
 3. **Be direct.** Don't soften critical issues.
+4. **Be fair.** Acknowledge what's done well.
 5. **Don't write code.** Identify issues and describe what "right" looks like.
 6. **Prioritize.** Clearly distinguish critical blockers from nice-to-haves.
 

--- a/.claude/agents/parallel-task-orchestrator.md
+++ b/.claude/agents/parallel-task-orchestrator.md
@@ -194,4 +194,4 @@ See `tasks/implementation-notes.md` for detailed decision log.
 
 # Persistent Memory
 
-`.claude/agent-memory/parallel-task-orchestrator/` — `MEMORY.md` (max 200 lines). Save: dependency patterns, file conflict patterns, failure resolutions. Don't save: session task results. Search: `Grep pattern="<term>" path=".claude/agent-memory/parallel-task-orchestrator/" glob="*.md"`
+Dir: `.claude/agent-memory/parallel-task-orchestrator/`. Save dependency/conflict patterns and failure resolutions to topic files; index in `MEMORY.md` (max 200 lines).

--- a/.claude/agents/prd-task-planner.md
+++ b/.claude/agents/prd-task-planner.md
@@ -241,8 +241,8 @@ The `README.md` should include:
 - [ ] Tasks collectively implement the full updated PRD?
 - [ ] Specific files and patterns referenced in every task?
 
-**Update agent memory** with discovered codepaths, patterns, key abstractions, and conventions — builds institutional knowledge across sessions.
+**Update agent memory** with discovered codepaths, patterns, key abstractions, and conventions.
 
 # Persistent Memory
 
-`.claude/agent-memory/prd-task-planner/` — `MEMORY.md` (max 200 lines); topic files for detail. Save: architecture, conventions, reusable utilities, testing setup. Don't save: session context, anything in CLAUDE.md. Search: `Grep pattern="<term>" path=".claude/agent-memory/prd-task-planner/" glob="*.md"`
+Dir: `.claude/agent-memory/prd-task-planner/`. Save architecture, conventions, reusable utilities, and testing setup to topic files; index in `MEMORY.md` (max 200 lines).

--- a/.claude/agents/qa-agent.md
+++ b/.claude/agents/qa-agent.md
@@ -299,4 +299,4 @@ After writing both outputs, print a summary:
 
 # Persistent Memory
 
-`.claude/agent-memory/qa-agent/` — `MEMORY.md` (max 200 lines); topic files: `known-selectors.md`, `flaky-patterns.md`, `app-flows.md`. Save: working selectors, auth bypasses, flaky areas. Don't save: session test results.
+Dir: `.claude/agent-memory/qa-agent/`. Save working selectors, auth bypasses, and flaky areas to topic files (`known-selectors.md`, `flaky-patterns.md`, `app-flows.md`); index in `MEMORY.md` (max 200 lines).

--- a/.claude/agents/refactor-planner.md
+++ b/.claude/agents/refactor-planner.md
@@ -174,4 +174,4 @@ tasks/
 
 # Persistent Memory
 
-`.claude/agent-memory/refactor-planner/` — `MEMORY.md` (max 200 lines); topic files for detail. Save: project structure, test framework/commands, naming conventions, patterns that worked. Don't save: session context, anything in CLAUDE.md. Search: `Grep pattern="<term>" path=".claude/agent-memory/refactor-planner/" glob="*.md"`
+Dir: `.claude/agent-memory/refactor-planner/`. Save project structure, test commands, naming conventions, and effective patterns to topic files; index in `MEMORY.md` (max 200 lines).

--- a/.claude/agents/task-implementer.md
+++ b/.claude/agents/task-implementer.md
@@ -119,4 +119,4 @@ Keep it concise — only include entries that a reviewer couldn't infer from rea
 
 # Persistent Memory
 
-`.claude/agent-memory/task-implementer/` — `MEMORY.md` (max 200 lines); topic files: `patterns.md`, `gotchas.md`. Save: conventions, import path gotchas, reusable utilities. Don't save: session task context, in-progress work. Search: `Grep pattern="<term>" path=".claude/agent-memory/task-implementer/" glob="*.md"`
+Dir: `.claude/agent-memory/task-implementer/`. Save conventions, import path gotchas, and reusable utilities to topic files (`patterns.md`, `gotchas.md`); index in `MEMORY.md` (max 200 lines).

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -7,7 +7,7 @@ color: cyan
 memory: project
 ---
 
-You are a senior software engineer specializing in writing high-quality, meaningful tests. You know the difference between tests that give confidence and tests that just add coverage numbers. You write tests that document behavior, catch regressions, and serve as a safety net for future changes.
+You are a senior software engineer specializing in writing high-quality, meaningful tests. You write tests that document behavior, catch regressions, and serve as a safety net for future changes.
 
 ## YOUR MISSION
 
@@ -101,4 +101,4 @@ Prioritize by impact:
 
 # Persistent Memory
 
-`.claude/agent-memory/test-writer/` — `MEMORY.md` (max 200 lines). Save: test framework/commands, naming conventions, mocking patterns, setup gotchas. Don't save: session context, anything in CLAUDE.md. Search: `Grep pattern="<term>" path=".claude/agent-memory/test-writer/" glob="*.md"`
+Dir: `.claude/agent-memory/test-writer/`. Save test framework/commands, naming conventions, mocking patterns, and setup gotchas to topic files; index in `MEMORY.md` (max 200 lines).


### PR DESCRIPTION
## Summary
- Condensed persistent memory sections across all 10 agent files — removed boilerplate `Don't save:` and `Search: Grep...` instructions that are implicit
- Removed filler language: hedging notes, redundant positioning statements, obvious advice (e.g., "You may deviate if evidence leads elsewhere")
- ~500 token savings with zero behavioral impact

## Test plan
- [ ] Verify agent memory still works correctly (agents write to their memory dirs)
- [ ] Spot-check that trimmed agents behave identically on a sample task

🤖 Generated with [Claude Code](https://claude.com/claude-code)