### PR TITLE
refactor: replace per-task commits with per-wave and per-task-at-end modes

### DIFF
--- a/.claude/agents/agent-teams-orchestrator.md
+++ b/.claude/agents/agent-teams-orchestrator.md
@@ -28,6 +28,7 @@ You are orchestrating task implementation using Claude Code's native Agent Teams
    - **Files to create or modify**: Which files this task touches
    - **Dependencies**: Explicit dependencies listed in the task
    - **Description**: Brief summary of what it does
+6. **Commit mode**: `COMMIT_MODE` is set by the SKILL session in Step 0.1 and is available as a session variable. Note its value for use in Phase 3e. Valid values: `squash`, `per-wave`, `per-task-at-end`, or unset (when `AUTO_COMMIT=false`).
 
 ## PHASE 2: DEPENDENCY ANALYSIS & COST OPTIMIZATION
 
@@ -193,8 +194,20 @@ After each wave:
   2. If the retry succeeds: use `TaskUpdate` to mark the task `status: "completed"`
   3. If the retry also fails: leave the task `status: "in_progress"`, note the failure, and assess whether dependent tasks can still proceed
 - Only retry once per task — do not retry the retry
+- **Per-wave commit** (only if `COMMIT_MODE=per-wave`): After all retries resolve for this wave, run:
+  ```bash
+  git add -A
+  git diff --staged --quiet || git commit -m "refactor: Wave N — <task objectives, 72-char subject>" -m "- Task XX: <objective>" -m "- Task YY: <objective>"
+  ```
+  Where:
+  - `N` is the wave number (1, 2, 3...)
+  - Subject line is `refactor: Wave N — ` followed by comma-joined task objectives, truncated to 72 chars at the last comma boundary before the limit, appending `...` if truncated
+  - Each `-m` after the first adds one body bullet per task in the wave using the task's `## Objective` text
+  - If the wave had failed tasks that were not recovered, note them in the commit body: `- Task XX: FAILED — <brief reason>`
+  - Skip the commit if there are no staged changes (`git diff --staged --quiet` returns 0 after `git add -A`)
+  - The commit subject prefix defaults to `refactor:` but the SKILL session can substitute a different prefix (e.g., `feat:` for build pipelines) since it executes these instructions directly
 
-> **Per-task commits**: Agent Teams mode does not support per-task commits (teammates run in parallel). If the user selected per-task commit mode, fall back to squash-style commit after all tasks complete.
+  For `per-task-at-end` and `squash` modes: the skill layer (Step 2.5b) handles commits after this orchestration phase completes.
 
 ## PHASE 4: COMPLETION
 

--- a/.claude/agents/parallel-task-orchestrator.md
+++ b/.claude/agents/parallel-task-orchestrator.md
@@ -27,6 +27,7 @@ You are a task orchestrator. Your job is to read task files, determine execution
    - **Files to create or modify**: Which files this task touches
    - **Dependencies**: Explicit dependencies listed in the task
    - **Description**: Brief summary of what it does
+6. **Check for commit mode**: If the launch prompt contains `COMMIT_MODE=per-wave`, set `COMMIT_MODE=per-wave`. Otherwise `COMMIT_MODE=none`. Note this for use in Phase 3.
 
 ## PHASE 2: DEPENDENCY ANALYSIS
 
@@ -110,6 +111,18 @@ After each wave:
   2. If the retry succeeds: use `TaskUpdate` to mark the task `status: "completed"`
   3. If the retry also fails: leave the task `status: "in_progress"`, note the failure, and assess whether dependent tasks can still proceed
 - Only retry once per task — do not retry the retry
+- **Per-wave commit** (only if `COMMIT_MODE=per-wave`): After all retries resolve for this wave, run:
+  ```bash
+  git add -A
+  git diff --staged --quiet || git commit -m "refactor: Wave N — <task objectives, 72-char subject>" -m "- Task XX: <objective>" -m "- Task YY: <objective>"
+  ```
+  Where:
+  - `N` is the wave number (1, 2, 3...)
+  - Subject line is `refactor: Wave N — ` followed by comma-joined task objectives, truncated to 72 chars at the last comma boundary before the limit, appending `...` if truncated
+  - Each `-m` after the first adds one body bullet per task in the wave using the task's `## Objective` text
+  - If the wave had failed tasks that were not recovered, note them in the commit body: `- Task XX: FAILED — <brief reason>`
+  - Skip the commit if there are no staged changes (`git diff --staged --quiet` returns 0 after `git add -A`)
+  - The commit subject prefix defaults to `refactor:` but can be overridden via the launch prompt (e.g., `Use commit subject prefix 'feat:'`)
 
 ## PHASE 4: COMPLETION
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -24,7 +24,11 @@ Ask: "Enable auto-commit and PR?" (Yes / No) → `AUTO_COMMIT`.
 
 **If `AUTO_COMMIT=true`:**
 1. Run `git rev-parse --abbrev-ref HEAD` to get `CURRENT_BRANCH`. If `CURRENT_BRANCH` is `main` or `master`: `BRANCH_ACTION=new`. Else ask: "Branch `<name>` exists — create new or commit here?" → `BRANCH_ACTION=new/current`.
-2. Ask: "Single squash commit or one commit per task?" → `COMMIT_MODE=squash/per-task`.
+2. Ask: "How should changes be committed?"
+   - **Squash** — single commit at the end summarizing all changes
+   - **Per-wave** — one commit per parallel execution wave (e.g., Wave 1: 3 tasks → 1 commit)
+   - **Per-task at end** — full parallel run, then one atomic commit per task in order
+   → `COMMIT_MODE=squash/per-wave/per-task-at-end`
 3. Generate `feat/<3-5-word-slug>` from PRD content → `AUTO_COMMIT_BRANCH`.
 4. **If `BRANCH_ACTION=new`:**
    - Run `git fetch origin` to get latest remote state.
@@ -185,11 +189,12 @@ Implement the tasks yourself, sequentially, in the current conversation context.
 3. Implement the task following the requirements and acceptance criteria
 4. If the task has a `## TDD Mode` section, follow the RED → GREEN → REFACTOR → VERIFY cycle (including test adequacy check)
 5. After each task, collect the Implementation Notes section from your work. After all tasks are done, write `tasks/implementation-notes.md` consolidating all notes.
-6. **If `COMMIT_MODE=per-task`:** after completing each task, run:
+6. **If `COMMIT_MODE=per-wave`:** after completing each task, check if the current "wave" (group of sequential tasks with no parallelism in fast-path) warrants a commit. In fast-path mode, commit after each task:
    ```bash
    git add -A
-   git commit -m "feat: <task-objective-from-task-file>"
+   git diff --staged --quiet || git commit -m "feat: <task-objective-from-task-file>"
    ```
+   **If `COMMIT_MODE=per-task-at-end`:** skip — commits are created in Step 2.5b after all tasks complete.
 
 This avoids orchestrator overhead and gives you continuous context across tasks — each task benefits from seeing the work done in previous tasks without reading files cold.
 
@@ -197,24 +202,11 @@ This avoids orchestrator overhead and gives you continuous context across tasks 
 
 **If `ORCHESTRATION_MODE=parallel`** (default):
 
-**If `COMMIT_MODE=per-task`:**
-
 Launch the `parallel-task-orchestrator` agent using the Task tool with:
 - `subagent_type: "parallel-task-orchestrator"`
 - Tell it to read and execute all tasks from `tasks/`
-- Include this additional instruction in the prompt:
-  > "Run tasks **sequentially** (one at a time, no parallel waves). After each task-implementer completes, run the following bash commands before starting the next task:
-  > ```bash
-  > git add -A
-  > git commit -m "feat: <task-objective-from-task-file>"
-  > ```
-  > Use the task's `## Objective` line as the commit message description."
-
-**If `COMMIT_MODE=squash` or `AUTO_COMMIT=false`:**
-
-Launch the `parallel-task-orchestrator` agent using the Task tool with:
-- `subagent_type: "parallel-task-orchestrator"`
-- Tell it to read and execute all tasks from `tasks/`
+- **If `COMMIT_MODE=per-wave`**: Include `COMMIT_MODE=per-wave` in the launch prompt so the orchestrator commits after each wave. Also include: `Use commit subject prefix 'feat:' instead of 'refactor:' for per-wave commits.`
+- **If `COMMIT_MODE=squash`, `per-task-at-end`, or `AUTO_COMMIT=false`**: Launch normally with no additional commit instructions.
 
 Wait for it to complete. Note any issues reported.
 
@@ -229,7 +221,7 @@ Do NOT spawn a sub-agent. Instead, execute Agent Teams orchestration directly in
 2. Follow those instructions directly in this session to orchestrate tasks using Agent Teams teammates
 3. Produce the same outputs: `tasks/implementation-notes.md` and `tasks/execution-metrics.md`
 
-Note: Per-task commits are not supported in Agent Teams mode (teammates run in parallel). If `COMMIT_MODE=per-task` was selected, fall back to squash-style commit after all tasks complete. Auto-commit/branch handling (if `AUTO_COMMIT=true`) applies identically to both modes.
+Note: Per-wave commits in Agent Teams mode are handled by the agent-teams-orchestrator when `COMMIT_MODE=per-wave` is passed in the session context. Per-task-at-end commits are handled by the skill layer in Step 2.5b (runs after Agent Teams execution completes). Auto-commit/branch handling (if `AUTO_COMMIT=true`) applies identically to both modes.
 
 After Agent Teams execution completes (whether successful or not), **clean up the env var**: read the settings file that was modified above, remove `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` from the `env` object, and write it back. If the `env` object is now empty, remove it entirely. This prevents the beta env var from persisting across future sessions.
 
@@ -256,8 +248,39 @@ After the build check, run the project's full test suite to catch regressions an
 **2.5a Safety:** Run `git rev-parse --abbrev-ref HEAD`. If `main`/`master`: abort ("Auto-commit aborted: on main/master. Commit manually.") → proceed to Step 3.
 
 **2.5b Commit:**
-- `COMMIT_MODE=squash`: `git add -A && git commit -m "feat: <PRD summary>" -m "- <task objective>..."` (72-char subject, ≤3 body bullets from task objectives).
-- `COMMIT_MODE=per-task`: already committed in Step 2. Skip to push.
+
+- **`COMMIT_MODE=squash`**: Read all `tasks/task-*.md` files. Extract the `## Objective` line from each. Run:
+  ```bash
+  git add -A
+  git commit -m "feat: <PRD summary>" -m "$(cat <<'EOF'
+  - <objective from task-01>
+  - <objective from task-02>
+  - <objective from task-03>
+  ... (one bullet per task, no cap)
+  EOF
+  )"
+  ```
+  Subject line: 72-char max. Body: one bullet per task objective, all listed (no bullet cap).
+
+- **`COMMIT_MODE=per-wave`**: Commits were made by the orchestrator (or fast-path) during execution. Run `git add -A` to catch any unstaged changes left after the final wave, then commit any remainder:
+  ```bash
+  git add -A
+  git diff --staged --quiet || git commit -m "feat: post-run cleanup"
+  ```
+  If nothing is staged after `git add -A`, skip the final commit.
+
+- **`COMMIT_MODE=per-task-at-end`**: Full parallel run is complete. Now create one commit per task in task-file order:
+  1. Run `git add -A` to stage all changes.
+  2. Read each `tasks/task-NN-*.md` file in numerical order.
+  3. For each task, extract its `## Objective` line and the list of files it touched (from the `## Target Files` section).
+  4. Use `git restore --staged .` to unstage everything, then selectively stage only the files for this task using `git add <file1> <file2> ...`, then commit:
+     ```bash
+     git restore --staged .
+     git add <files for this task>
+     git commit -m "feat: <task objective>"
+     ```
+  5. Repeat for each task in order.
+  6. After all per-task commits, run `git add -A && git diff --staged --quiet || git commit -m "feat: miscellaneous changes"` to catch any files not covered by the task-file manifests.
 
 **2.5d Push:** `git push -u origin <branch-name>`. On failure, show manual command and continue.
 

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -20,7 +20,11 @@ Ask: "Enable auto-commit and PR?" (Yes / No) → `AUTO_COMMIT`.
 
 **If `AUTO_COMMIT=true`:**
 1. Run `git rev-parse --abbrev-ref HEAD` to get `CURRENT_BRANCH`. If `CURRENT_BRANCH` is `main` or `master`: `BRANCH_ACTION=new`. Else ask: "Branch `<name>` exists — create new or commit here?" → `BRANCH_ACTION=new/current`.
-2. Ask: "Single squash commit or one commit per task?" → `COMMIT_MODE=squash/per-task`.
+2. Ask: "How should changes be committed?"
+   - **Squash** — single commit at the end summarizing all changes
+   - **Per-wave** — one commit per parallel execution wave (e.g., Wave 1: 3 tasks → 1 commit)
+   - **Per-task at end** — full parallel run, then one atomic commit per task in order
+   → `COMMIT_MODE=squash/per-wave/per-task-at-end`
 3. Generate `refactor/<3-5-word-slug>` from `$ARGUMENTS` → `AUTO_COMMIT_BRANCH`.
 4. **If `BRANCH_ACTION=new`:**
    - Run `git fetch origin` to get latest remote state.
@@ -148,24 +152,11 @@ Wait for it to complete. Confirm tests pass before proceeding — do not start r
 
 **If `ORCHESTRATION_MODE=parallel`** (default):
 
-**If `COMMIT_MODE=per-task`:**
-
 Launch the `parallel-task-orchestrator` agent using the Task tool with:
 - `subagent_type: "parallel-task-orchestrator"`
 - Tell it to read and execute all tasks from `tasks/`
-- Include this additional instruction in the prompt:
-  > "Run tasks **sequentially** (one at a time, no parallel waves). After each task-implementer completes, run the following bash commands before starting the next task:
-  > ```bash
-  > git add -A
-  > git commit -m "refactor: <task-objective-from-task-file>"
-  > ```
-  > Use the task's `## Objective` line as the commit message description."
-
-**If `COMMIT_MODE=squash` or `AUTO_COMMIT=false`:**
-
-Launch the `parallel-task-orchestrator` agent using the Task tool with:
-- `subagent_type: "parallel-task-orchestrator"`
-- Tell it to read and execute all tasks from `tasks/`
+- **If `COMMIT_MODE=per-wave`**: Include `COMMIT_MODE=per-wave` in the launch prompt so the orchestrator commits after each wave.
+- **If `COMMIT_MODE=squash`, `per-task-at-end`, or `AUTO_COMMIT=false`**: Launch normally with no additional commit instructions.
 
 Wait for it to complete. Note any issues reported.
 
@@ -180,7 +171,7 @@ Do NOT spawn a sub-agent. Instead, execute Agent Teams orchestration directly in
 2. Follow those instructions directly in this session to orchestrate tasks using Agent Teams teammates
 3. Produce the same outputs: `tasks/implementation-notes.md` and `tasks/execution-metrics.md`
 
-Note: Per-task commits are not supported in Agent Teams mode (teammates run in parallel). If `COMMIT_MODE=per-task` was selected, fall back to squash-style commit after all tasks complete. Auto-commit/branch handling (if `AUTO_COMMIT=true`) applies identically to both modes.
+Note: Per-wave commits in Agent Teams mode are handled by the agent-teams-orchestrator when `COMMIT_MODE=per-wave` is passed in the session context. Per-task-at-end commits are handled by the skill layer in Step 2.5b (runs after Agent Teams execution completes).
 
 After Agent Teams execution completes (whether successful or not), **clean up the env var**: read the settings file that was modified above, remove `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` from the `env` object, and write it back. If the `env` object is now empty, remove it entirely. This prevents the beta env var from persisting across future sessions.
 
@@ -207,8 +198,39 @@ This step is especially critical for refactoring — the primary success criteri
 **2.5a Safety:** Run `git rev-parse --abbrev-ref HEAD`. If `main`/`master`: abort ("Auto-commit aborted: on main/master. Commit manually.") → proceed to Step 3.
 
 **2.5b Commit:**
-- `COMMIT_MODE=squash`: Read `tasks/refactor-plan.md` (or derive from task objectives). `git add -A && git commit -m "refactor: <$ARGUMENTS summary>" -m "- <improvement 1>..."` (72-char subject, ≤3 body bullets).
-- `COMMIT_MODE=per-task`: already committed in Step 2. Skip to push.
+
+- **`COMMIT_MODE=squash`**: Read all `tasks/task-*.md` files. Extract the `## Objective` line from each. Run:
+  ```bash
+  git add -A
+  git commit -m "refactor: <$ARGUMENTS summary>" -m "$(cat <<'EOF'
+  - <objective from task-01>
+  - <objective from task-02>
+  - <objective from task-03>
+  ... (one bullet per task, no cap)
+  EOF
+  )"
+  ```
+  Subject line: 72-char max. Body: one bullet per task objective, all listed (no 3-bullet cap).
+
+- **`COMMIT_MODE=per-wave`**: Commits were made by the orchestrator during execution. Run `git add -A` to catch any unstaged changes left after the final wave, then commit any remainder:
+  ```bash
+  git add -A
+  git diff --staged --quiet || git commit -m "refactor: post-run cleanup"
+  ```
+  If nothing is staged after `git add -A`, skip the final commit.
+
+- **`COMMIT_MODE=per-task-at-end`**: Full parallel run is complete. Now create one commit per task in task-file order:
+  1. Run `git add -A` to stage all changes.
+  2. Read each `tasks/task-NN-*.md` file in numerical order.
+  3. For each task, extract its `## Objective` line and the list of files it touched (from the `## Target Files` section).
+  4. Use `git restore --staged .` to unstage everything, then selectively stage only the files for this task using `git add <file1> <file2> ...`, then commit:
+     ```bash
+     git restore --staged .
+     git add <files for this task>
+     git commit -m "refactor: <task objective>"
+     ```
+  5. Repeat for each task in order.
+  6. After all per-task commits, run `git add -A && git diff --staged --quiet || git commit -m "refactor: miscellaneous changes"` to catch any files not covered by the task-file manifests.
 
 **2.5d Push:** `git push -u origin <branch-name>`. On failure, show manual command and continue.
 


### PR DESCRIPTION
## Summary

Replaces the old per-task commit mode (which forced sequential execution, blocking all parallelism) with two new modes that preserve full wave-based parallelism while producing meaningful commit history.

## Changes

- **Removed** old `per-task` commit mode from refactor SKILL (forced sequential execution)
- **Added** `per-wave` commits to `parallel-task-orchestrator` — orchestrator commits after each wave, gated on `COMMIT_MODE=per-wave` signal
- **Added** `per-wave` commits to `agent-teams-orchestrator` — matching format and behavior
- **Wired** three commit mode options into refactor SKILL: Squash / Per-wave / Per-task at end
- **Created** build SKILL (`build/SKILL.md`) with three-mode commit system and `feat:` prefix
- **Improved** squash commit messages — now lists all task objectives (removed 3-bullet cap)

### New Commit Modes

| Mode | Parallelism | History | When commits happen |
|------|-------------|---------|-------------------|
| Squash | Full | 1 commit (all objectives listed) | End of run |
| Per-wave | Full | 1 commit per wave | After each wave completes |
| Per-task at end | Full | 1 commit per task | End of run, selective staging |

## Behavior Preservation

- No test suite exists (markdown instruction files)
- No build system detected
- All changes are to markdown instruction files — no runtime code affected
- `squash` mode behavior is preserved (only change: richer commit messages)
- Old `per-task` mode (sequential) is removed — strictly superseded by new modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable commit strategies: squash, per-wave (one commit per parallel wave), and per-task-at-end; per-wave commits only occur when there are staged changes.

* **Changes**
  * Removed live per-task commit behavior during parallel runs; per-task commits are now deferred to the end when using per-task-at-end.
  * Commit messages and subject prefixes can be constructed from task objectives and overridden via launch settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->