### PR TITLE
feat: add plan-review mode to code-reviewer (closes #17)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -238,10 +238,11 @@ When plan-review criteria are included in your prompt, run the following checks 
 **Output contract — read this first.** You MUST emit the `### Plan Issues Found` section in your report, even when no issues are found. When a severity bucket (Critical / Important / Minor) has no items, write `- None` under that heading. The caller parses this section programmatically; omitting it or using an alternate heading will break the pipeline.
 
 **Check 1 — Dependency soundness**
-- For every task with `Depends on: [task-N]`, verify that task-N exists as a file in `$TASKS_DIR/`
-- Check for circular dependencies (task A depends on B, B depends on C, C depends on A)
-- Check for missing dependency declarations: if task B reads output from task A or modifies a file that task A also modifies, it should declare `Depends on: task-A`
-- Severity guidance: missing dep declarations → Important; circular deps → Critical; phantom dep references (task-N doesn't exist) → Critical
+- Parse each task's `## Dependencies` section. The `prd-task-planner` writes dependencies as task numbers (e.g., `- Depends on: 1, 3` or `- Depends on: None`), but humans editing task files may use prefixed forms (`task-01`, `task-01-add-auth`). **Normalize each dependency token before validation**: strip whitespace and any `task-` prefix, parse the leading integer, then match against task files by their leading numeric prefix (`task-01-*.md` → `1`, with or without zero-padding). Treat `None` / empty / missing as "no dependencies".
+- For every normalized dependency N, verify a task file matching `task-<N>*.md` (or `task-0<N>*.md` for zero-padded variants) exists in `$TASKS_DIR/`. A dep that doesn't resolve to any file after normalization is phantom.
+- Check for circular dependencies (task A depends on B, B depends on C, C depends on A) using the normalized IDs.
+- Check for missing dependency declarations: if task B reads output from task A or modifies a file that task A also modifies, it should declare a dependency on A.
+- Severity guidance: missing dep declarations → Important; circular deps → Critical; phantom dep references (no matching task file after normalization) → Critical.
 
 **Check 2 — PRD coverage gaps**
 - Read `$TASKS_DIR/updated-prd.md`. For every acceptance criterion and requirement in the PRD, identify which task implements it

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -231,6 +231,99 @@ When implementation notes are available, also include:
 **Decision Assessment**: [brief — did implementers make good calls? Any patterns of concern?]
 ```
 
+### Plan Review Criteria
+
+When plan-review criteria are included in your prompt, run the following checks on the task files in `tasks/` before producing the review report. Read all `tasks/task-*.md` files and `tasks/updated-prd.md` first.
+
+**Check 1 — Dependency soundness**
+- For every task with `Depends on: [task-N]`, verify that task-N exists as a file in `tasks/`
+- Check for circular dependencies (task A depends on B, B depends on C, C depends on A)
+- Check for missing dependency declarations: if task B reads output from task A or modifies a file that task A also modifies, it should declare `Depends on: task-A`
+- Severity guidance: missing dep declarations → Important; circular deps → Critical; phantom dep references (task-N doesn't exist) → Critical
+
+**Check 2 — PRD coverage gaps**
+- Read `tasks/updated-prd.md`. For every acceptance criterion and requirement in the PRD, identify which task implements it
+- Flag any PRD requirement that no task covers
+- Flag any task that has no clear mapping to a PRD requirement (scope creep)
+- Severity guidance: uncovered acceptance criteria → Critical; uncovered requirements → Important; unmapped tasks → Minor
+
+**Check 3 — Task file conflicts**
+- Identify all files that appear in more than one task's `## Implementation Details` or `## Existing Code References` sections as targets for modification
+- For each shared file, verify the tasks modify non-overlapping parts OR that the later task depends on the earlier task
+- Flag concurrent modification of the same file with no dependency ordering as a conflict
+- Severity guidance: unordered concurrent writes to the same file → Critical; same file referenced in read-only context by multiple tasks → acceptable, no issue
+
+**Check 4 — Task sizing**
+- Review each task for signs of being too large (single task implementing an entire subsystem with many unrelated files) or too small (a single line rename warranting its own task file)
+- "Too large" signal: Objective spans multiple distinct concerns, Implementation Details section touches 5+ unrelated files, or Acceptance Criteria lists 10+ unrelated checks
+- "Too small" signal: Entire task could be completed in under 5 minutes by a human, or it is a pure rename/constant change with no logic
+- Severity guidance: oversized tasks that risk partial completion → Important; trivial tasks that add orchestration overhead → Minor
+
+**Check 5 — TDD spec consistency**
+- For tasks that include a `## TDD Mode` section: verify the test file path follows detected project conventions, the test framework matches what exists in the repo, and the test command is real (check for its presence in `package.json`, `Makefile`, etc.)
+- Flag TDD sections that reference non-existent test frameworks or commands
+- Flag tasks without a `## TDD Mode` section when the updated PRD states TDD was requested
+- Severity guidance: TDD section referencing a non-existent framework → Important; missing TDD section when TDD was requested → Important; test command not discoverable → Important
+
+When plan-review criteria are provided in your prompt, include the following section in your report:
+
+```markdown
+## Plan Review
+
+### Dependency Graph
+
+| Task | Depends On | Status |
+|------|-----------|--------|
+| task-01 | None | ✅ Valid |
+| task-02 | task-01 | ✅ Valid |
+
+**Dependency Assessment**: [circular deps, phantom refs, undeclared deps — or "No issues found"]
+
+### PRD Coverage
+
+| PRD Requirement | Covered By | Status |
+|----------------|-----------|--------|
+| [requirement] | task-N | ✅ Covered |
+| [requirement] | — | ❌ Not covered |
+
+**Coverage Score**: X/Y requirements covered
+
+### File Conflict Analysis
+
+| File | Tasks Touching It | Conflict? |
+|------|------------------|-----------|
+| [file path] | task-01, task-02 | ✅ Ordered (02 depends on 01) |
+| [file path] | task-02, task-03 | ❌ Concurrent write, no dependency |
+
+**Conflict Assessment**: [issues found or "No conflicts detected"]
+
+### Task Sizing
+
+| Task | Assessment | Notes |
+|------|-----------|-------|
+| task-01 | ✅ Well-sized | |
+| task-02 | ⚠️ Oversized | [reason] |
+
+### TDD Spec Consistency
+
+| Task | Has TDD Section | Framework Valid | Command Valid | Status |
+|------|----------------|-----------------|--------------|--------|
+| task-01 | Yes | Yes | Yes | ✅ |
+
+**TDD Spec Assessment**: [brief]
+
+### Plan Issues Found
+
+#### Critical (blocks implementation)
+- [description]
+
+#### Important (should fix before proceeding)
+- [description]
+
+#### Minor (nice to fix)
+- [description]
+```
+
 ## SAVING THE REPORT
 
 If your prompt specifies an output file path (e.g., `$TASKS_DIR/review-report.md`), write the full report to that file using the Write tool. Always output the report as text too so the caller sees it.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -233,16 +233,16 @@ When implementation notes are available, also include:
 
 ### Plan Review Criteria
 
-When plan-review criteria are included in your prompt, run the following checks on the task files in `tasks/` before producing the review report. Read all `tasks/task-*.md` files and `tasks/updated-prd.md` first.
+When plan-review criteria are included in your prompt, run the following checks on the task files in `$TASKS_DIR/` before producing the review report. Read all `$TASKS_DIR/task-*.md` files and `$TASKS_DIR/updated-prd.md` first.
 
 **Check 1 — Dependency soundness**
-- For every task with `Depends on: [task-N]`, verify that task-N exists as a file in `tasks/`
+- For every task with `Depends on: [task-N]`, verify that task-N exists as a file in `$TASKS_DIR/`
 - Check for circular dependencies (task A depends on B, B depends on C, C depends on A)
 - Check for missing dependency declarations: if task B reads output from task A or modifies a file that task A also modifies, it should declare `Depends on: task-A`
 - Severity guidance: missing dep declarations → Important; circular deps → Critical; phantom dep references (task-N doesn't exist) → Critical
 
 **Check 2 — PRD coverage gaps**
-- Read `tasks/updated-prd.md`. For every acceptance criterion and requirement in the PRD, identify which task implements it
+- Read `$TASKS_DIR/updated-prd.md`. For every acceptance criterion and requirement in the PRD, identify which task implements it
 - Flag any PRD requirement that no task covers
 - Flag any task that has no clear mapping to a PRD requirement (scope creep)
 - Severity guidance: uncovered acceptance criteria → Critical; uncovered requirements → Important; unmapped tasks → Minor

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -231,9 +231,11 @@ When implementation notes are available, also include:
 **Decision Assessment**: [brief — did implementers make good calls? Any patterns of concern?]
 ```
 
-### Plan Review Criteria
+## Plan Review Criteria
 
 When plan-review criteria are included in your prompt, run the following checks on the task files in `$TASKS_DIR/` before producing the review report. Read all `$TASKS_DIR/task-*.md` files and `$TASKS_DIR/updated-prd.md` first.
+
+**Output contract — read this first.** You MUST emit the `### Plan Issues Found` section in your report, even when no issues are found. When a severity bucket (Critical / Important / Minor) has no items, write `- None` under that heading. The caller parses this section programmatically; omitting it or using an alternate heading will break the pipeline.
 
 **Check 1 — Dependency soundness**
 - For every task with `Depends on: [task-N]`, verify that task-N exists as a file in `$TASKS_DIR/`
@@ -315,14 +317,16 @@ When plan-review criteria are provided in your prompt, include the following sec
 ### Plan Issues Found
 
 #### Critical (blocks implementation)
-- [description]
+- [description, or `- None` if no issues in this bucket]
 
 #### Important (should fix before proceeding)
-- [description]
+- [description, or `- None` if no issues in this bucket]
 
 #### Minor (nice to fix)
-- [description]
+- [description, or `- None` if no issues in this bucket]
 ```
+
+**Always emit all three severity buckets** (Critical / Important / Minor). If a bucket has no items, emit `- None` beneath it. Do not omit the `### Plan Issues Found` section or any of its sub-headings.
 
 ## SAVING THE REPORT
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -193,10 +193,10 @@ This step always runs. Do not skip it.
    Then add: "You can also open and edit any file in `$TASKS_DIR/` directly before proceeding."
 
 3. Use `AskUserQuestion` with a single question: "How would you like to proceed?"
-   - **"Looks good — start implementation"** — continue to Step 2
+   - **"Looks good — start implementation"** — continue to Step 1e
    - **"Regenerate with feedback"** — user provides feedback via the "Other" field
 
-4. **If user approves**: proceed to Step 2.
+4. **If user approves**: proceed to Step 1e.
 
 5. **If user requests regeneration**: resume the **same** prd-task-planner agent (from Step 1a/1c) with:
    - `resume: "<agent-id-from-step-1a>"`

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -227,23 +227,24 @@ Before launching the orchestrator, analyze the task files to determine if orches
 
 Launch the `code-reviewer` agent using the Task tool with:
 - `subagent_type: "code-reviewer"`
-- Tell it to evaluate all task files in `tasks/` and `tasks/updated-prd.md` using plan-review criteria
-- Tell it to write the plan review report to `tasks/plan-review-report.md`
-- Include these plan-review criteria in the prompt:
-  > Apply the plan-review checks defined in your `### Plan Review Criteria` section: (1) Dependency soundness, (2) PRD coverage gaps, (3) Task file conflicts, (4) Task sizing, (5) TDD spec consistency. Read all `tasks/task-*.md` files and `tasks/updated-prd.md`. Write the plan review report to `tasks/plan-review-report.md`.
+- Prompt:
+  ```
+  TASKS_DIR=$TASKS_DIR
+  Apply the plan-review checks defined in your `### Plan Review Criteria` section: (1) Dependency soundness, (2) PRD coverage gaps, (3) Task file conflicts, (4) Task sizing, (5) TDD spec consistency. Read all `$TASKS_DIR/task-*.md` files and `$TASKS_DIR/updated-prd.md`. Write the plan review report to `$TASKS_DIR/plan-review-report.md`.
+  ```
 
 Wait for it to complete.
 
 ### 1f.2: Present plan review results
 
-1. Read `tasks/plan-review-report.md`. Extract the `### Plan Issues Found` section (Critical / Important / Minor items).
+1. Read `$TASKS_DIR/plan-review-report.md`. Extract the `### Plan Issues Found` section (Critical / Important / Minor items).
 
 2. Present the plan issues summary to the user as a formatted list. If no issues were found in any category, note "No plan issues found."
 
 3. Use `AskUserQuestion` with a single question: "How would you like to proceed?"
    - **"Proceed anyway"** — continue to Step 2 (even if issues were found)
    - **"Regenerate with feedback"** — user provides feedback via the "Other" field; the planner will regenerate task files incorporating the plan review findings and user feedback
-   - **"Edit files manually"** — user edits task files in `tasks/` directly, then re-runs plan review
+   - **"Edit files manually"** — user edits task files in `$TASKS_DIR/` directly, then re-runs plan review
 
 ### 1f.3: Handle user choice
 
@@ -253,12 +254,12 @@ Wait for it to complete.
 1. Collect the user's feedback from their response
 2. Resume the **same** `prd-task-planner` agent (agent ID from Step 1a) with:
    - `resume: "<agent-id-from-step-1a>"`
-   - Prompt: `MODE: GENERATE\n\nPlan review found issues requiring changes. User feedback:\n<feedback>\n\nPlan review report summary:\n<contents of Plan Issues Found section from tasks/plan-review-report.md>\n\nPlease regenerate the task files addressing these issues.`
+   - Prompt: `TASKS_DIR=$TASKS_DIR\n\nMODE: GENERATE\n\nPlan review found issues requiring changes. User feedback:\n<feedback>\n\nPlan review report summary:\n<contents of Plan Issues Found section from $TASKS_DIR/plan-review-report.md>\n\nPlease regenerate the task files addressing these issues.`
 3. Wait for regeneration to complete
 4. **Loop back to the top of Step 1f.1** — re-run the plan review on the new task files
 
 **If "Edit files manually"**:
-1. Display: "Edit the files in `tasks/` directly. When done, reply to continue."
+1. Display: "Edit the files in `$TASKS_DIR/` directly. When done, reply to continue."
 2. Wait for user confirmation
 3. **Loop back to the top of Step 1f.1** — re-run the plan review against the edited files
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -223,6 +223,8 @@ Before launching the orchestrator, analyze the task files to determine if orches
 
 **Skip this step only if there are 2 or fewer tasks.** Plan review is cheap insurance for any plan large enough to have real dependency or scoping risk — run it even for 3+ task sequential plans (FAST_PATH decoupling: skipping the orchestrator is not a reason to skip the sanity check).
 
+**Initialize `PLAN_REVIEW_ITER = 1`** as you enter Step 1f (before 1f.1). Increment it each time you loop back to 1f.1 from 1f.3. Used below to drive the iteration-3 nudge.
+
 ### 1f.1: Launch plan review
 
 Launch the `code-reviewer` agent using the Task tool with:
@@ -253,9 +255,9 @@ Wait for it to complete.
 
 ### 1f.3: Handle user choice
 
-Track an iteration counter `PLAN_REVIEW_ITER` in your session state. Initialize it to `1` the first time you enter Step 1f.1, and increment it by 1 each time you loop back.
+(The `PLAN_REVIEW_ITER` counter was initialized at the top of Step 1f. Read below for how it gates the soft nudge.)
 
-**Loop guardrail — soft nudge after iteration 3.** If `PLAN_REVIEW_ITER >= 3` and the user selects "Regenerate with feedback" or "Edit files manually" again, insert this message before proceeding: "Heads up — this is plan-review iteration N. If the reviewer keeps flagging the same class of issue, consider either editing files manually (if you haven't), picking 'Proceed anyway' and fixing at implementation time, or stopping to revise the PRD itself." Then honor the user's choice. Do not hard-cap the loop.
+**Loop guardrail — soft nudge after iteration 3.** If `PLAN_REVIEW_ITER >= 3` AND the user's choice at 1f.2 was either "Regenerate with feedback" or "Edit files manually" (i.e., any choice that will cause a loop-back to 1f.1), insert this message before proceeding with that choice: "Heads up — this is plan-review iteration N. If the reviewer keeps flagging the same class of issue, consider either editing files manually (if you haven't), picking 'Proceed anyway' and fixing at implementation time, or stopping to revise the PRD itself." Then honor the user's choice. The nudge fires on every looping iteration from N=3 onward, not just once. Do not hard-cap the loop.
 
 **If "Proceed anyway"**:
 Log "Plan review issues noted. Proceeding to implementation." Continue to Step 2. This is a valid exit regardless of whether issues remain.

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -219,6 +219,51 @@ Before launching the orchestrator, analyze the task files to determine if orches
 
 **Set `FAST_PATH=false` otherwise** (3+ tasks with real parallelism opportunities).
 
+## Step 1f: Plan review — Validate task plan soundness
+
+**Skip this step if `FAST_PATH=true`.** For ≤2 tasks or all-sequential plans, orchestration overhead is not justified and plan review is skipped.
+
+### 1f.1: Launch plan review
+
+Launch the `code-reviewer` agent using the Task tool with:
+- `subagent_type: "code-reviewer"`
+- Tell it to evaluate all task files in `tasks/` and `tasks/updated-prd.md` using plan-review criteria
+- Tell it to write the plan review report to `tasks/plan-review-report.md`
+- Include these plan-review criteria in the prompt:
+  > Apply the plan-review checks defined in your `### Plan Review Criteria` section: (1) Dependency soundness, (2) PRD coverage gaps, (3) Task file conflicts, (4) Task sizing, (5) TDD spec consistency. Read all `tasks/task-*.md` files and `tasks/updated-prd.md`. Write the plan review report to `tasks/plan-review-report.md`.
+
+Wait for it to complete.
+
+### 1f.2: Present plan review results
+
+1. Read `tasks/plan-review-report.md`. Extract the `### Plan Issues Found` section (Critical / Important / Minor items).
+
+2. Present the plan issues summary to the user as a formatted list. If no issues were found in any category, note "No plan issues found."
+
+3. Use `AskUserQuestion` with a single question: "How would you like to proceed?"
+   - **"Proceed anyway"** — continue to Step 2 (even if issues were found)
+   - **"Regenerate with feedback"** — user provides feedback via the "Other" field; the planner will regenerate task files incorporating the plan review findings and user feedback
+   - **"Edit files manually"** — user edits task files in `tasks/` directly, then re-runs plan review
+
+### 1f.3: Handle user choice
+
+**If "Proceed anyway"**: Log "Plan review issues noted. Proceeding to implementation." Continue to Step 2.
+
+**If "Regenerate with feedback"**:
+1. Collect the user's feedback from their response
+2. Resume the **same** `prd-task-planner` agent (agent ID from Step 1a) with:
+   - `resume: "<agent-id-from-step-1a>"`
+   - Prompt: `MODE: GENERATE\n\nPlan review found issues requiring changes. User feedback:\n<feedback>\n\nPlan review report summary:\n<contents of Plan Issues Found section from tasks/plan-review-report.md>\n\nPlease regenerate the task files addressing these issues.`
+3. Wait for regeneration to complete
+4. **Loop back to the top of Step 1f.1** — re-run the plan review on the new task files
+
+**If "Edit files manually"**:
+1. Display: "Edit the files in `tasks/` directly. When done, reply to continue."
+2. Wait for user confirmation
+3. **Loop back to the top of Step 1f.1** — re-run the plan review against the edited files
+
+There is no hard retry cap — the loop continues until the user chooses "Proceed anyway."
+
 ## Step 2: Implement
 
 ### Fast path (`FAST_PATH=true`) — Direct implementation

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -221,7 +221,7 @@ Before launching the orchestrator, analyze the task files to determine if orches
 
 ## Step 1f: Plan review — Validate task plan soundness
 
-**Skip this step if `FAST_PATH=true`.** For ≤2 tasks or all-sequential plans, orchestration overhead is not justified and plan review is skipped.
+**Skip this step only if there are 2 or fewer tasks.** Plan review is cheap insurance for any plan large enough to have real dependency or scoping risk — run it even for 3+ task sequential plans (FAST_PATH decoupling: skipping the orchestrator is not a reason to skip the sanity check).
 
 ### 1f.1: Launch plan review
 
@@ -230,7 +230,12 @@ Launch the `code-reviewer` agent using the Task tool with:
 - Prompt:
   ```
   TASKS_DIR=$TASKS_DIR
-  Apply the plan-review checks defined in your `### Plan Review Criteria` section: (1) Dependency soundness, (2) PRD coverage gaps, (3) Task file conflicts, (4) Task sizing, (5) TDD spec consistency. Read all `$TASKS_DIR/task-*.md` files and `$TASKS_DIR/updated-prd.md`. Write the plan review report to `$TASKS_DIR/plan-review-report.md`.
+
+  MODE: PLAN REVIEW
+
+  Apply the five plan-review checks defined under the "Plan Review Criteria" heading in your own agent definition: (1) Dependency soundness, (2) PRD coverage gaps, (3) Task file conflicts, (4) Task sizing, (5) TDD spec consistency.
+
+  Read all `$TASKS_DIR/task-*.md` files and `$TASKS_DIR/updated-prd.md` before running the checks. Write the plan review report to `$TASKS_DIR/plan-review-report.md`. You MUST emit the `### Plan Issues Found` section with all three severity buckets (Critical / Important / Minor) — use `- None` for buckets with no issues. Do not omit the section or any sub-heading.
   ```
 
 Wait for it to complete.
@@ -248,22 +253,31 @@ Wait for it to complete.
 
 ### 1f.3: Handle user choice
 
-**If "Proceed anyway"**: Log "Plan review issues noted. Proceeding to implementation." Continue to Step 2.
+Track an iteration counter `PLAN_REVIEW_ITER` in your session state. Initialize it to `1` the first time you enter Step 1f.1, and increment it by 1 each time you loop back.
+
+**Loop guardrail — soft nudge after iteration 3.** If `PLAN_REVIEW_ITER >= 3` and the user selects "Regenerate with feedback" or "Edit files manually" again, insert this message before proceeding: "Heads up — this is plan-review iteration N. If the reviewer keeps flagging the same class of issue, consider either editing files manually (if you haven't), picking 'Proceed anyway' and fixing at implementation time, or stopping to revise the PRD itself." Then honor the user's choice. Do not hard-cap the loop.
+
+**If "Proceed anyway"**:
+Log "Plan review issues noted. Proceeding to implementation." Continue to Step 2. This is a valid exit regardless of whether issues remain.
 
 **If "Regenerate with feedback"**:
-1. Collect the user's feedback from their response
-2. Resume the **same** `prd-task-planner` agent (agent ID from Step 1a) with:
+
+1. Collect the user's feedback from their `AskUserQuestion` response (the "Other" field).
+2. **Validate feedback is non-empty.** If the user picked "Regenerate with feedback" but left the "Other" field blank (or provided only whitespace), re-prompt via `AskUserQuestion`: "Regeneration needs either specific feedback or a direction. Provide feedback, or switch to 'Edit files manually' / 'Proceed anyway'." Do not resume the planner with an empty feedback block — it has no new signal to work from and will likely produce a near-identical plan.
+3. Read `$TASKS_DIR/plan-review-report.md` and extract the `### Plan Issues Found` section contents (the reviewer's output contract guarantees this section exists).
+4. Resume the **same** `prd-task-planner` agent (agent ID from Step 1a) with:
    - `resume: "<agent-id-from-step-1a>"`
-   - Prompt: `TASKS_DIR=$TASKS_DIR\n\nMODE: GENERATE\n\nPlan review found issues requiring changes. User feedback:\n<feedback>\n\nPlan review report summary:\n<contents of Plan Issues Found section from $TASKS_DIR/plan-review-report.md>\n\nPlease regenerate the task files addressing these issues.`
-3. Wait for regeneration to complete
-4. **Loop back to the top of Step 1f.1** — re-run the plan review on the new task files
+   - Prompt: `TASKS_DIR=$TASKS_DIR\n\nMODE: GENERATE\n\nPlan review found issues requiring changes. User feedback:\n<feedback text collected in step 1>\n\nPlan review findings:\n<contents of "### Plan Issues Found" section extracted in step 3>\n\nPlease regenerate the task files addressing these issues.`
+5. Wait for regeneration to complete.
+6. Increment `PLAN_REVIEW_ITER` and **loop back to the top of Step 1f.1** — re-run the plan review on the new task files.
 
 **If "Edit files manually"**:
-1. Display: "Edit the files in `$TASKS_DIR/` directly. When done, reply to continue."
-2. Wait for user confirmation
-3. **Loop back to the top of Step 1f.1** — re-run the plan review against the edited files
 
-There is no hard retry cap — the loop continues until the user chooses "Proceed anyway."
+1. Display: "Edit the files in `$TASKS_DIR/` directly. When done, reply to continue."
+2. Wait for user confirmation.
+3. Increment `PLAN_REVIEW_ITER` and **loop back to the top of Step 1f.1** — re-run the plan review against the edited files.
+
+**Loop exit conditions.** The loop exits whenever the user selects "Proceed anyway" at Step 1f.2, regardless of iteration count or remaining issues. A clean review ("No plan issues found") still requires the user to confirm via "Proceed anyway" — the skill does not auto-advance. There is no hard retry cap.
 
 ## Step 2: Implement
 


### PR DESCRIPTION
## Summary
- Adds a `### Plan Review Criteria` section to `code-reviewer.md` with five pre-implementation checks: dependency soundness, PRD coverage gaps, task file conflicts, task sizing, and TDD spec consistency
- Adds `Step 1f` to `build/SKILL.md` that invokes code-reviewer in plan-review mode after fast-path detection, with a show-and-ask loop (Proceed / Regenerate / Edit manually)
- Skipped on fast-path (≤2 tasks) to avoid overhead

## Changes
- `.claude/agents/code-reviewer.md` — new Plan Review Criteria section with severity guidance and report format template
- `.claude/skills/build/SKILL.md` — new Step 1f between Step 1e and Step 2

Closes #17

## Review Notes
- Follows the existing prompt-driven pattern (same as TDD criteria injection)
- No existing content was modified — pure additions
- The regeneration loop in Step 1f reuses the planner agent ID from Step 1a (same pattern as Step 1d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive plan-review step that validates task dependency soundness, PRD coverage, file conflict risks, task sizing heuristics, and TDD consistency; produces a structured plan-review report and lets users Proceed / Regenerate with feedback / Edit and re-run. Skips for very small plans. Includes a soft nudge after multiple iterations.

* **Documentation**
  * Expanded review criteria, added a structured plan-review report template and a required "Plan Issues Found" summary with Critical / Important / Minor buckets; added input validation for regeneration feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->