### PR TITLE
docs(tdd): restrict mocks to system boundary

### DIFF
--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -34,6 +34,12 @@ You receive a **bug diagnosis** (from `tasks/bug-diagnosis.md` or a description 
 - If the test unexpectedly passes, reassess the diagnosis — the bug may already be fixed or the test is wrong
 - **If the test fails for wrong reasons** (import errors, missing modules, syntax errors): fix the test setup, not the test logic. Re-run. Max 3 fix-and-retry cycles before escalating as a blocker.
 
+**Mocking discipline** (critical — prevents silent regressions):
+- Mock only at the **system boundary**: paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem I/O.
+- Do NOT mock the code under test, or **internal modules it calls**. A regression test that mocks the very module where the bug lived (or its internal dependencies) can pass while the bug is still present. Use real internal collaborators; use in-memory instances or lightweight fakes if setup is heavy.
+- Do NOT mock a layer *above* the real boundary (mock the HTTP client / SDK / DB driver, not a wrapper around it).
+- When mocking a real boundary, the mock's shape and behavior must match the real dependency — shared types, recorded fixtures, or a reusable fake beat ad-hoc stubs.
+
 **If TDD is not feasible, document why and proceed with a verification plan:**
 - No test framework configured in the project **and** installing one is outside scope
 - Bug is in infrastructure/configuration (CI, Docker, env vars) that has no testable interface

--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -38,7 +38,7 @@ You receive a **bug diagnosis** (from `tasks/bug-diagnosis.md` or a description 
 - Mock only at the **system boundary**: paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem I/O.
 - Do NOT mock the code under test, or **internal modules it calls**. A regression test that mocks the very module where the bug lived (or its internal dependencies) can pass while the bug is still present. Use real internal collaborators; use in-memory instances or lightweight fakes if setup is heavy.
 - Do NOT mock a layer *above* the real boundary (mock the HTTP client / SDK / DB driver, not a wrapper around it).
-- When mocking a real boundary, the mock's shape and behavior must match the real dependency — shared types, recorded fixtures, or a reusable fake beat ad-hoc stubs.
+- When mocking a real boundary, the mock's shape and behavior must match the real dependency. Prefer shared types / recorded fixtures / a reusable thin fake over ad-hoc stubs returning whatever a particular test happens to need.
 
 **If TDD is not feasible, document why and proceed with a verification plan:**
 - No test framework configured in the project **and** installing one is outside scope

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -99,6 +99,7 @@ If TDD-specific review criteria are included in your prompt, also evaluate TDD c
 - Read each new test file. For every `it()`/`test()`/`def test_` block, verify: (a) it calls the code under test, (b) it asserts on the result or side-effect, (c) the assertion is specific enough to catch a real regression
 - Flag tests that only assert on type/existence ("toBeDefined", "not null") without checking actual values
 - Flag tests where the expected value is hardcoded to match current output without testing the logic (snapshot-style assertions in unit tests)
+- **Mocking discipline**: flag tests that mock the code under test, or mock internal modules the code under test calls into. Mocks belong at the system boundary (paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem) — mocking internals produces silently-passing tests that miss real regressions. Also flag mocks placed one layer above the real boundary (e.g., mocking a `UserRepository` wrapper instead of the underlying DB driver), since a regression in the wrapper stays invisible.
 - If a task had TDD mode but the implementer declared "TDD not feasible", verify the stated reason is valid — flag if the project has a working test framework and the reason is vague
 
 ### Step 4b: Test Execution Verification

--- a/.claude/agents/prd-task-planner.md
+++ b/.claude/agents/prd-task-planner.md
@@ -219,6 +219,12 @@ This task uses Test-Driven Development. Write tests BEFORE implementation.
 2. Implement the minimum code to make them pass (GREEN)
 3. Run the full test suite to check for regressions
 4. Refactor if needed while keeping tests green
+
+### Mocking Discipline
+- Mock only at the **system boundary**: paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem I/O.
+- Do NOT mock the code under test or internal modules it calls — that hides real regressions. Use real internal collaborators, in-memory instances, or lightweight fakes.
+- Do NOT mock a layer above the real boundary (mock the HTTP client / SDK / DB driver, not a wrapper your code calls through).
+- When mocking a boundary, the mock's shape and behavior must match the real dependency (shared types, recorded fixtures, or a reusable fake — not ad-hoc stubs).
 ```
 
 #### Task Decomposition Principles

--- a/.claude/agents/prd-task-planner.md
+++ b/.claude/agents/prd-task-planner.md
@@ -198,7 +198,7 @@ Each task file MUST contain:
 - Blocks: [task numbers that depend on this task]
 ```
 
-When TDD mode was requested by the user, task files for functional code tasks MUST also include the following optional section:
+When TDD mode was requested by the user, task files for functional code tasks MUST also include the following optional section (copy the template below verbatim into each TDD task file, including the `### Mocking Discipline` block):
 
 ```markdown
 ## TDD Mode

--- a/.claude/agents/task-implementer.md
+++ b/.claude/agents/task-implementer.md
@@ -50,6 +50,12 @@ Before writing code, check the conventions in the relevant app/package:
 - If tests unexpectedly pass, note this — the requirement may already be met or the test needs adjustment
 - **If tests fail for wrong reasons** (import errors, missing modules, syntax errors): fix the test setup, not the test logic. Re-run. Max 3 fix-and-retry cycles before escalating as a blocker.
 
+**Mocking discipline** (critical — prevents silent regressions):
+- Mock only at the **system boundary**: paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem I/O.
+- Do NOT mock the code under test, or **internal modules it calls**. Using real internal collaborators is what makes the test catch real regressions. If an internal module is hard to set up, use an in-memory instance or a lightweight fake — not a mock.
+- Do NOT mock a layer *above* the real boundary (mock the HTTP client / SDK / DB driver, not your own service wrapper around it — otherwise a regression in the wrapper is invisible).
+- When mocking a real boundary, the mock's shape and behavior must match the real dependency. Prefer shared types / recorded fixtures / a reusable thin fake over ad-hoc stubs returning whatever a particular test happens to need.
+
 **If TDD is not feasible**, document why and fall back to Step 4 (Standard Mode). Valid reasons:
 - No test framework configured in the project **and** installing one is outside task scope
 - The code is infrastructure/configuration (e.g., CI config, Docker, env vars) that has no testable interface

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -36,7 +36,7 @@ For the target code, identify:
 - **Edge cases**: empty inputs, zero values, boundary conditions, large inputs
 - **Error cases**: invalid inputs, missing required fields, network failures, permission errors
 - **Branches**: every significant `if/else`, `switch`, `try/catch` that can be exercised
-- **Integration points**: if the code calls external services/DB, test with mocks
+- **Integration points**: if the code calls external services/DB, mock at the boundary (see Mocking Discipline below)
 
 Prioritize by impact:
 1. Core business logic (highest value)
@@ -51,8 +51,18 @@ Prioritize by impact:
   - **Focused**: one assertion per test where practical, or one scenario per test
   - **Independent**: no shared mutable state between tests
   - **Realistic**: use realistic test data, not just `foo`, `bar`, `1`, `2`
-- Mock external dependencies (DB, HTTP, file system) — do NOT let tests hit real services
+- Mock external dependencies (DB, HTTP, file system) — do NOT let tests hit real services. Follow the Mocking Discipline rules below.
 - Group related tests with `describe` blocks (or equivalent)
+
+### Mocking Discipline
+Mocks are for the **system boundary only**. Anything further in is a silent-regression risk.
+
+- **Mock:** paid/external APIs, network calls, wall clock & randomness, destructive side effects (emails, payments), filesystem I/O
+- **Do NOT mock:**
+  - The code under test, or **internal modules it calls**. Mocking internal collaborators lets real bugs or refactor breakage pass green.
+  - Internal code just because it's inconvenient to set up. Use real instances, in-memory implementations, or lightweight fakes instead.
+  - A layer *above* the boundary. Mock the HTTP client / SDK / DB driver — not a service wrapper your code calls through, because a regression in the wrapper would be invisible.
+- **When you do mock a boundary**, the mock's shape and behavior must match the real dependency. Prefer shared types, recorded fixtures, or a reusable thin fake over ad-hoc stubs that return whatever a particular test happens to need.
 
 ### Step 5: Run and fix
 - Run the new tests using the detected test command
@@ -96,7 +106,7 @@ Prioritize by impact:
 2. **Read before writing.** Understand code and test patterns first.
 3. **Write tests that could fail.** A test that always passes is worthless.
 4. **Match project conventions exactly.** Framework, naming, imports, assertion style.
-5. **Mock external dependencies.** No real network calls, DB queries, or file I/O.
+5. **Mock at the boundary, not inside it.** External deps (network, DB, filesystem, paid APIs, time, randomness) get mocked. Internal code — including the code under test and its internal collaborators — never does. Mocking internals is the #1 source of silently-passing tests.
 6. **Run your tests.** Fix failures before reporting.
 
 # Persistent Memory

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -61,7 +61,7 @@ Mocks are for the **system boundary only**. Anything further in is a silent-regr
 - **Do NOT mock:**
   - The code under test, or **internal modules it calls**. Mocking internal collaborators lets real bugs or refactor breakage pass green.
   - Internal code just because it's inconvenient to set up. Use real instances, in-memory implementations, or lightweight fakes instead.
-  - A layer *above* the boundary. Mock the HTTP client / SDK / DB driver — not a service wrapper your code calls through, because a regression in the wrapper would be invisible.
+  - A layer *above* the boundary. Mock the HTTP client / SDK / DB driver — not a service wrapper your code calls through, because a regression in the wrapper would be invisible. Concrete example: mock `pg.Pool.query` (the driver), not `UserRepository.findById` (a wrapper the code under test calls through).
 - **When you do mock a boundary**, the mock's shape and behavior must match the real dependency. Prefer shared types, recorded fixtures, or a reusable thin fake over ad-hoc stubs that return whatever a particular test happens to need.
 
 ### Step 5: Run and fix


### PR DESCRIPTION
## Summary
- Adds a consistent **Mocking Discipline** rule across the four TDD-related agents so mocks can only live at the system boundary, not inside internal code.
- Prevents the silent-regression failure mode where a test passes green because a mock stands in for the very module that regressed.

## Rule added
Mock **only** at the system boundary: paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem I/O.

Do NOT mock:
- The code under test or **internal modules it calls** — a regression in those stays invisible.
- Internal code just because setup is inconvenient (use real instances, in-memory impls, or lightweight fakes).
- A layer *above* the real boundary (mock the HTTP client / SDK / DB driver, not your own wrapper around it).

When mocking a boundary, the mock's shape/behavior must match the real dependency (shared types, recorded fixtures, or a reusable fake — not ad-hoc stubs).

## Files changed
- `.claude/agents/test-writer.md` — replaced the three "mock externals" touchpoints with the boundary rule.
- `.claude/agents/task-implementer.md` — added the discipline inside TDD Step 4a (RED).
- `.claude/agents/bug-fixer.md` — added inside Step 3, with a bug-fixer-specific note that mocking the bug's own module can leave the bug unfixed.
- `.claude/agents/prd-task-planner.md` — added to the `## TDD Mode` task template so per-task specs inherit it.

## Test plan
- [ ] Skim each updated agent file and confirm the new section reads clearly in context
- [ ] Run a `/build` with TDD mode on and confirm task files render the new Mocking Discipline block
- [ ] Run `/debug-workflow` on a sample bug and confirm bug-fixer's RED step applies the rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a cross-workflow "Mocking Discipline": only mock at system boundaries (external APIs, network, time/randomness, destructive side effects, filesystem I/O); forbid mocking the code under test, internal collaborators, or layers above the real boundary. Require mocks to match real dependency shape/behavior via shared types, recorded fixtures, or reusable thin fakes to reduce silent test regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->