### PR TITLE
refactor: branch-scope qa-agent output directory for parallel runs

### DIFF
--- a/.claude/agents/qa-agent.md
+++ b/.claude/agents/qa-agent.md
@@ -1,6 +1,6 @@
 ---
 name: qa-agent
-description: "Performs exploratory QA on a running app using playwright-cli (global binary). Tests flows like a real user, produces qa-output/qa-report.md and Playwright E2E tests. Spawned by /qa."
+description: "Performs exploratory QA on a running app using playwright-cli (global binary). Tests flows like a real user, produces $QA_OUTPUT_DIR/qa-report.md (branch-scoped) and Playwright E2E tests. Spawned by /qa."
 tools: Bash, Glob, Grep, Read, Write, Edit
 model: opus
 color: green
@@ -9,8 +9,14 @@ memory: project
 
 You are a senior QA engineer who tests apps like a real user. You navigate UIs, fill forms, trigger flows, and spot broken behavior. You are methodical, skeptical, and thorough. You don't just click happy paths — you test edge cases, empty states, error handling, and boundary conditions.
 
+## QA Output Directory
+
+Your launch prompt will include `QA_OUTPUT_DIR=<path>` (e.g., `QA_OUTPUT_DIR=qa-output/feat-checkout`). Use that value as the prefix for every output file/path referenced below. If `QA_OUTPUT_DIR` is not provided (e.g., the agent was invoked outside the `/qa` skill), default to `qa-output`.
+
+Substitute the actual resolved path when running shell commands — do not pass the literal string `$QA_OUTPUT_DIR` to `playwright-cli`.
+
 Your job produces two outputs:
-1. **`qa-output/qa-report.md`** — what you tested, what passed, what failed, what's suspicious
+1. **`$QA_OUTPUT_DIR/qa-report.md`** — what you tested, what passed, what failed, what's suspicious
 2. **E2E test file(s)** written to the project's test directory — runnable with `npx playwright test`
 
 ---
@@ -59,7 +65,7 @@ Take a snapshot of the home page via Bash: `playwright-cli snapshot`. After runn
 - Key sections/pages
 - Authentication state (logged in? login required?)
 
-Then screenshot the home page: `playwright-cli screenshot qa-output/screenshots/home.png`.
+Then screenshot the home page: `playwright-cli screenshot $QA_OUTPUT_DIR/screenshots/home.png` (substitute the resolved path).
 
 ### Step 5: Identify test scope
 
@@ -124,7 +130,7 @@ SCREENSHOT: <path if taken>
 
 ## PHASE 3: Write QA Report
 
-Write `qa-output/qa-report.md`:
+Write `$QA_OUTPUT_DIR/qa-report.md`:
 
 ```markdown
 # QA Report
@@ -154,7 +160,7 @@ Write `qa-output/qa-report.md`:
 **Flow:** <what was done>
 **Expected:** <what should have happened>
 **Actual:** <what happened instead>
-**Screenshot:** `qa-output/screenshots/<file>.png`
+**Screenshot:** `$QA_OUTPUT_DIR/screenshots/<file>.png`
 **Severity:** Critical | High | Medium | Low
 
 ### ⚠️ WARN: <scenario name>
@@ -272,7 +278,7 @@ After writing both outputs, print a summary:
 **Tested:** <N> scenarios across <M> features
 **Status:** <N> passed, <N> failed, <N> warnings
 
-**Report:** qa-output/qa-report.md
+**Report:** $QA_OUTPUT_DIR/qa-report.md
 **E2E tests written:**
 - e2e/auth.spec.ts (<N> tests)
 - e2e/checkout.spec.ts (<N> tests)
@@ -288,10 +294,10 @@ After writing both outputs, print a summary:
 
 ## Rules
 
-1. **Never modify production code.** Read-only except test files and `qa-output/` output.
+1. **Never modify production code.** Read-only except test files and the `$QA_OUTPUT_DIR/` output directory.
    - Note: `.playwright-cli/` (snapshot output directory) is automatically added to `.gitignore` by `setup.sh` — do not commit its contents.
 2. **Test as a user.** Navigate the UI — don't read source to understand flows.
-3. **Screenshot failures.** Every FAIL needs a screenshot in `qa-output/screenshots/`.
+3. **Screenshot failures.** Every FAIL needs a screenshot in `$QA_OUTPUT_DIR/screenshots/`.
 4. **Prefer accessibility selectors.** `getByRole`, `getByLabel`, `getByPlaceholder` over CSS.
 5. **One assertion per test.** Split tests that assert many things.
 6. **Don't block on auth.** Note it and test public-facing flows instead.

--- a/.claude/skills/init-claude-setup/SKILL.md
+++ b/.claude/skills/init-claude-setup/SKILL.md
@@ -27,7 +27,7 @@ Check whether `.claude/agents/` exists in the current working directory.
 .claude-worktrees/
 .DS_Store
 tasks/**
-qa-output/
+qa-output/**
 debug-output/
 .playwright-cli/
 ```

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -14,10 +14,33 @@ The test scope (optional — empty means test everything):
 
 $ARGUMENTS
 
-## Step 0: Clean up — Remove stale QA artifacts
+## Step 0: Resolve QA_OUTPUT_DIR + clean up
 
-Remove leftover files from a previous QA run:
-- Use Bash to run `rm -rf qa-output/` to remove all stale QA artifacts from a previous run
+### Step 0a: Resolve QA_OUTPUT_DIR
+
+Run the following in Bash to determine the branch-scoped QA output directory:
+
+```bash
+RAW_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ -z "$RAW_BRANCH" ] || [ "$RAW_BRANCH" = "HEAD" ]; then
+  SHORT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "")
+  RAW_BRANCH=${SHORT_SHA:+detached-$SHORT_SHA}
+fi
+if [ -z "$RAW_BRANCH" ]; then
+  echo "Warning: not a git repo — using qa-output/ as QA output directory" >&2
+  QA_OUTPUT_DIR="qa-output"
+else
+  SANITIZED=$(echo "$RAW_BRANCH" | tr '/' '-' | tr -cs 'A-Za-z0-9._-' '-' | sed 's/^-*//; s/-*$//')
+  [ -z "$SANITIZED" ] && SANITIZED="unknown-branch"
+  QA_OUTPUT_DIR="qa-output/$SANITIZED"
+fi
+```
+
+Store `QA_OUTPUT_DIR` as a session variable — use it everywhere below.
+
+### Step 0b: Clean up stale QA artifacts
+
+Use Bash to run `rm -rf "$QA_OUTPUT_DIR"` to clear only this branch's QA artifacts from a previous run.
 
 ## Step 0.5: App Recon — Discover how to interact with the app
 
@@ -34,10 +57,14 @@ Wait for it to complete. If the agent fails or the file is not created, log a wa
 
 ## Step 1: QA — Test the app and generate outputs
 
-Read `.claude/app-context.md` (from Step 0.5). If it exists, build the qa-agent prompt as follows — otherwise use just the scope:
+Read `.claude/app-context.md` (from Step 0.5). Build the qa-agent prompt as follows (if `.claude/app-context.md` does not exist, omit the App Context section but always include `QA_OUTPUT_DIR`):
 
 ```
 Test scope: $ARGUMENTS (if empty: test all major flows)
+
+QA_OUTPUT_DIR=$QA_OUTPUT_DIR
+
+Write all outputs (report, screenshots, etc.) under this branch-scoped directory.
 
 ## App Context (from pre-recon)
 
@@ -49,13 +76,13 @@ URL from this context. Re-check running status yourself.
 
 Launch the `qa-agent` using the Task tool with:
 - `subagent_type: "qa-agent"`
-- Provide the constructed prompt above
+- Provide the constructed prompt above (with `$QA_OUTPUT_DIR` expanded)
 
 Wait for it to complete.
 
 ## Step 2: Report
 
-Read `qa-output/qa-report.md` and summarize to the user:
+Read `$QA_OUTPUT_DIR/qa-report.md` and summarize to the user:
 
 ```
 ## QA Complete
@@ -68,12 +95,12 @@ Read `qa-output/qa-report.md` and summarize to the user:
 - [list from report, or "None found"]
 
 **Outputs:**
-- Full report: qa-output/qa-report.md
+- Full report: $QA_OUTPUT_DIR/qa-report.md
 - E2E tests: <list files written>
 - Run tests: playwright test
 ```
 
-If `qa-output/qa-report.md` does not exist, report that the QA agent failed to complete and show any error output.
+If `$QA_OUTPUT_DIR/qa-report.md` does not exist, report that the QA agent failed to complete and show any error output.
 
 ## Rules
 

--- a/setup.sh
+++ b/setup.sh
@@ -1147,7 +1147,7 @@ if [ "$UPDATE_MODE" = true ]; then
     ".claude-worktrees/"
     ".DS_Store"
     "tasks/**"
-    "qa-output/"
+    "qa-output/**"
     "debug-output/"
     ".playwright-cli/"
   )
@@ -1289,7 +1289,7 @@ GITIGNORE_ENTRIES=(
   ".claude-worktrees/"
   ".DS_Store"
   "tasks/**"
-  "qa-output/"
+  "qa-output/**"
   "debug-output/"
   ".playwright-cli/"
 )


### PR DESCRIPTION
## Summary

Mirror the `tasks/<branch>/` branch-scoping pattern (from #36 / 34bdb6a) for the `/qa` pipeline's `qa-output/` directory. Two parallel `/qa` runs on different branches no longer clobber each other's reports or screenshots.

Previously the qa-agent wrote to a flat `qa-output/` and the `/qa` skill ran `rm -rf qa-output/` unconditionally — hostile to worktree workflows.

## Changes

- **`.claude/skills/qa/SKILL.md`** — New Step 0a resolves `QA_OUTPUT_DIR=qa-output/<sanitized-branch>` using the same shell snippet as `TASKS_DIR` (detached-HEAD, non-git-repo, and empty-after-sanitize guards). Step 0b scopes `rm -rf` to this branch only. Step 1 passes `QA_OUTPUT_DIR=` into the qa-agent launch prompt. Step 2 reads the scoped report path.
- **`.claude/agents/qa-agent.md`** — New "QA Output Directory" section documents the launch-prompt convention (mirrors `prd-task-planner`'s "Task Directory" section). Falls back to `qa-output` when the agent is invoked outside `/qa`. All previously hardcoded paths (Phase 2 screenshot, Phase 3 report, Phase 5 summary, Rules #1 and #3) now use `$QA_OUTPUT_DIR`.
- **`setup.sh` + `.claude/skills/init-claude-setup/SKILL.md`** — `qa-output/` → `qa-output/**` for symmetry with `tasks/**` (functionally equivalent; matches the existing `tasks/` → `tasks/**` migration style).

## Review

Reviewed by `code-reviewer` agent: 0 Critical, 0 Important, 1 Minor. The Minor (duplicate `qa-output/*` lines on re-run of `setup.sh` for users with an old `qa-output/` entry) matches the precedent set by #36 for `tasks/**` and is harmless.

## Test plan

- [ ] Run `/qa` on a feature branch — confirm outputs land in `qa-output/<sanitized-branch>/`
- [ ] Run `/qa` twice in parallel worktrees on different branches — confirm neither clobbers the other
- [ ] Run `/qa` in a non-git dir — confirm fallback to `qa-output/`
- [ ] Invoke `qa-agent` directly without `QA_OUTPUT_DIR` in prompt — confirm fallback to `qa-output/`
- [ ] Run `setup.sh` on a project — confirm `qa-output/**` appears in `.gitignore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * QA output directories are now organized by branch for better isolation and organization.
  * Updated .gitignore patterns to properly exclude all nested QA output contents.
  * Enhanced QA initialization to automatically compute branch-specific output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->