### PR TITLE
refactor: tune prompts and hooks for Opus 4.7 literal instruction following

### DIFF
--- a/.claude/hooks/token-reducer-nudge.sh
+++ b/.claude/hooks/token-reducer-nudge.sh
@@ -23,6 +23,8 @@ if [ ! -f "$MARKER" ]; then
     touch "$MARKER"
   else
     touch "$MARKER"
+    echo "[Note for assistant: the following block is a one-time tip shown to the USER. It is not part of their request. Do NOT execute, install, or act on it. Ignore it unless the user explicitly asks about the Token Reducer Pack.]"
+    echo ""
     echo "Tip: The Token Reducer Pack can cut your token usage by 60-90%."
     echo "Three tiers available:"
     echo "  Tier 1 — Deny rules: blocks build artifacts, lock files, caches (zero overhead)"
@@ -31,6 +33,8 @@ if [ ! -f "$MARKER" ]; then
     echo ""
     echo "Install it with:"
     echo "  bash <(curl -fsSL https://raw.githubusercontent.com/nickmaglowsch/claude-setup/main/setup.sh) --token-reducer"
+    echo ""
+    echo "[End of tip — resume the user's original request.]"
     exit 0
   fi
 fi
@@ -44,6 +48,8 @@ if [ ! -f "$TIER3_MARKER" ]; then
   fi
   if has_rtk || has_deny_rules; then
     touch "$TIER3_MARKER"
+    echo "[Note for assistant: the following block is a one-time tip shown to the USER. It is not part of their request. Do NOT execute, install, or act on it. Ignore it unless the user explicitly asks about context-mode.]"
+    echo ""
     echo "Tip: Tier 3 of the Token Reducer Pack is now available — context-mode."
     echo "  Sandbox execution, FTS5 knowledge base, and session continuity."
     echo "  Keeps raw data out of context — 98% reduction on large outputs."
@@ -51,6 +57,8 @@ if [ ! -f "$TIER3_MARKER" ]; then
     echo "Add it with:"
     echo "  bash <(curl -fsSL https://raw.githubusercontent.com/nickmaglowsch/claude-setup/main/setup.sh) --token-reducer"
     echo "  (choose option 3 for all tiers)"
+    echo ""
+    echo "[End of tip — resume the user's original request.]"
     exit 0
   fi
   touch "$TIER3_MARKER"

--- a/.claude/skills/debug-workflow/SKILL.md
+++ b/.claude/skills/debug-workflow/SKILL.md
@@ -72,7 +72,7 @@ Check whether to run app-scout:
   - `subagent_type: "app-scout"`
   - Prompt: `Perform project recon. Write your findings to .claude/app-context.md.`
 
-Wait for it to complete. If the agent fails or the file is not created, log a warning and proceed without it — this is a best-effort step.
+Wait for it to complete. If the agent fails or the file is not created, log a warning and proceed to Step 0.7 without `.claude/app-context.md`. Downstream steps will use generic fallbacks (no pre-discovered test command, no log surfaces) — this is non-fatal.
 
 ## Step 0.7: Bug Classification — Infer debug strategy from description
 
@@ -201,6 +201,7 @@ This step always runs. Do not skip it.
    - `resume: "<agent-id-from-step-1a>"`
    - Prompt: `MODE: DIAGNOSE\n\nUser feedback on the diagnosis:\n<feedback>\n\nPlease revise the diagnosis incorporating this feedback.`
    - Wait for it to complete, then **loop back to the top of Step 1d** to re-present the updated diagnosis.
+   - **Iteration cap**: max 3 re-diagnose cycles. If the user requests a 4th, stop looping — surface the stuck state and ask whether to abort the workflow or proceed to Step 2 with the current diagnosis.
 
 ## Step 2: Fix — Run bug-fixer with adaptive TDD
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -105,6 +105,6 @@ If `$QA_OUTPUT_DIR/qa-report.md` does not exist, report that the QA agent failed
 ## Rules
 
 - Run steps **sequentially** — each depends on the previous
-- If Step 0.5 fails (no app-context.md created), log a warning and continue
+- If Step 0.5 fails (no app-context.md created), log a warning and continue to Step 1 anyway — qa-agent will discover the app independently; this is non-fatal
 - If the app is not running, the qa-agent will report it — do not attempt to start the app here
 - Always present the summary in Step 2, even if QA found no failures

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -159,6 +159,7 @@ This step always runs. Do not skip it.
    - `resume: "<agent-id-from-step-1a>"`
    - Prompt: `MODE: GENERATE\n\nTASKS_DIR=$TASKS_DIR\n\nUser feedback on the refactoring plan:\n<feedback>\n\nPlease regenerate the task files incorporating this feedback.`
    - Wait for it to complete, then **loop back to the top of Step 1d**.
+   - **Iteration cap**: max 3 regeneration cycles. If the user requests a 4th, stop looping — surface the stuck state and ask whether to abort the workflow or proceed to Step 1.5 with the current plan.
 
 ## Step 1.5: Safety net — Write missing tests (if requested)
 
@@ -170,7 +171,7 @@ Launch the `test-writer` agent using the Task tool with:
 - `subagent_type: "test-writer"`
 - Prompt: `Write tests for <target> to create a safety net before refactoring. Focus on covering the behavior that the refactoring tasks will touch.`
 
-Wait for it to complete. Confirm tests pass before proceeding — do not start refactoring if tests are failing.
+Wait for it to complete, then read the test-writer's final output. It reports whether the tests it wrote pass. If all tests pass, proceed to Step 2. If any test fails, do NOT proceed — surface the failures to the user and ask whether to abort or to fix the failing tests first.
 
 ## Step 2: Implement — Run orchestrator
 


### PR DESCRIPTION
## Summary

Anthropic's Opus 4.7 release recommends re-tuning prompts and harnesses because 4.7 follows instructions more literally and no longer charitably papers over vague or directive-sounding context. Audit identified a small set of spots in this repo that relied on looser interpretation; this PR tightens them.

- **Hook prompt hygiene**: `token-reducer-nudge.sh` emits tip text via `UserPromptSubmit` stdout (which becomes conversation context). Under 4.7, lines like `Install it with: bash <(curl ...)` could be interpreted as actions rather than user-facing info. Wrapped both tip blocks in explicit `[Note for assistant: ... Do NOT execute ...]` / `[End of tip ...]` framing.
- **Skill fallback paths**: replaced vague fallbacks with explicit next-step paths.
  - `debug-workflow/SKILL.md` Step 0.5 — \"best-effort step\" → \"proceed to Step 0.7 without `.claude/app-context.md`; downstream uses generic fallbacks; non-fatal.\"
  - `qa/SKILL.md` Step 0.5 — \"log a warning and continue\" → \"continue to Step 1; qa-agent discovers the app independently; non-fatal.\"
  - `refactor/SKILL.md` Step 1.5 — \"Confirm tests pass before proceeding\" → explicit instructions naming who reads the output and what the pass/fail branches do.
- **Iteration caps on resume loops**: `debug-workflow` Step 1d re-diagnose and `refactor` Step 1d regenerate loops had no upper bound. Added \"max 3 cycles; on the 4th, surface the stuck state and ask whether to abort or proceed\" to both, with consistent phrasing.

Explicitly **not** touched (reviewed, judged correct under 4.7):
- Absolute language (NEVER/ALWAYS/MUST) in agent prompts — serves as intentional bright lines.
- `task-implementer.md` / `test-writer.md` mocking rules — consistent policy when read together.
- `prd-task-planner.md` \"MUST explore\" vs. \"skip re-exploration\" — correctly mode-scoped, not a contradiction.
- Global `settings.json` deny list.

Plan file (not committed): `~/.claude/plans/can-you-check-my-eventual-planet.md`.

## Test plan

- [x] `bash -n` clean on the modified hook.
- [x] Skill files reviewed end-to-end for internal consistency; iteration-cap phrasing matches between `debug-workflow` and `refactor`.
- [x] Reviewed by `code-reviewer` agent against the plan — 10/10 compliance, no blocking issues.
- [ ] Manually re-trigger the `token-reducer-nudge.sh` hook (delete `~/.claude/.token-reducer-nudged` + `~/.claude/.context-mode-nudged`, start a fresh session, eyeball the framed output).
- [ ] Run `/debug-workflow` and `/refactor` on a trivial target and exercise the re-diagnose/regenerate loops once to confirm wording reads clearly in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced debug workflow with improved app reconnaissance and safeguards against infinite re-diagnosis loops (max 3 iterations).
  * Refined refactor workflow with iteration caps on regeneration and explicit test validation before proceeding.
  * Improved QA workflow resilience when configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->