### PR TITLE
feat: worktree opt-in for /build, /refactor, /debug-workflow

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -38,9 +38,46 @@ Ask: "Enable auto-commit and PR?" (Yes / No) → `AUTO_COMMIT`.
      - Option 2: `<CURRENT_BRANCH>` (current branch)
      - Option 3: Other (enter branch name)
    - Store chosen base as `BASE_BRANCH`.
-   - Run `git checkout -b <AUTO_COMMIT_BRANCH> <BASE_BRANCH>`. On failure append `-2`, retry once.
+   - **Do not create the branch yet** — Step 0.1b performs the actual `git checkout -b` or `git worktree add -b` based on the worktree choice.
 
 **If `AUTO_COMMIT=false`:** `BRANCH_ACTION=none`, `COMMIT_MODE=none`.
+
+## Step 0.1b: Worktree opt-in and branch creation
+
+Ask: "Run workflow in a new git worktree? (enables running multiple pipelines in parallel in the same project)" (Yes / No) → `USE_WORKTREE`.
+
+Store `WORKTREE_PATH=""` as the default. It is set to the new worktree's relative path only if one is created.
+
+### If `USE_WORKTREE=false`:
+
+- **If `AUTO_COMMIT=true` AND `BRANCH_ACTION=new`**: run `git checkout -b <AUTO_COMMIT_BRANCH> <BASE_BRANCH>`. On failure append `-2` to `AUTO_COMMIT_BRANCH`, retry once.
+- Otherwise: take no action here. Continue to Step 0.2.
+
+### If `USE_WORKTREE=true`:
+
+1. **If `AUTO_COMMIT=true` AND `BRANCH_ACTION=current`**: worktrees require a fresh branch (git disallows two worktrees on the same branch). Ask: "Worktree needs a new branch. Switch to a new branch, or skip the worktree and commit on the current branch?"
+   - **"Create new branch"** → set `BRANCH_ACTION=new`. Generate `AUTO_COMMIT_BRANCH=feat/<3-5-word-slug>` from the PRD content if not already generated. Run the same base-branch Q&A as Step 0.1 step 4 to pick `BASE_BRANCH`.
+   - **"Skip worktree"** → set `USE_WORKTREE=false` and fall through to the `USE_WORKTREE=false` branch above.
+
+2. Resolve the worktree branch and base:
+   - **If `AUTO_COMMIT=true`**: `WT_BRANCH=$AUTO_COMMIT_BRANCH`, `WT_BASE=$BASE_BRANCH` (both set in Step 0.1).
+   - **If `AUTO_COMMIT=false`**:
+     - Ask: "Branch name for the worktree?" Suggest `feat/<3-5-word-slug>` derived from the PRD content. Store as `WT_BRANCH`.
+     - Run `git fetch origin` and detect `DEFAULT_BRANCH` (same as Step 0.1 step 4).
+     - Get `CURRENT_BRANCH` if not already set.
+     - Ask: "Which branch should `<WT_BRANCH>` be based on?" with the same three options (default / current / other). Store as `WT_BASE`.
+
+3. Sanitize `$WT_BRANCH` into a filesystem-safe path segment (same rules as Step 0a's `SANITIZED`): replace `/` with `-`, strip non-`[A-Za-z0-9._-]`, trim leading/trailing dashes. Store as `WT_PATH_SEG`.
+
+4. Create the worktree and branch atomically:
+   ```bash
+   git worktree add -b "$WT_BRANCH" ".claude-worktrees/$WT_PATH_SEG" "$WT_BASE"
+   ```
+   On failure (branch or path already exists), append `-2` to both `$WT_BRANCH` and `$WT_PATH_SEG` and retry once. If it still fails, abort with a clear error to the user.
+
+5. `cd ".claude-worktrees/$WT_PATH_SEG"`. All subsequent steps run inside the worktree.
+
+6. Set `WORKTREE_PATH=".claude-worktrees/$WT_PATH_SEG"` for the final report.
 
 ## Step 0.2: Orchestration Mode Selection
 
@@ -477,6 +514,12 @@ Summarize the full pipeline run to the user:
   OR
 - Branch: <branch-name>
 - PR: <url or "manual command displayed">
+
+### Worktree
+- [omit this section entirely if `WORKTREE_PATH` is empty]
+  OR
+- Path: <WORKTREE_PATH>
+- Cleanup: `git worktree remove <WORKTREE_PATH>` (run from the original repo root)
 
 ### Next Steps
 - [what the user should do — e.g., run tests, fix issues, deploy]

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -73,7 +73,7 @@ Store `WORKTREE_PATH=""` as the default. It is set to the new worktree's relativ
    ```bash
    git worktree add -b "$WT_BRANCH" ".claude-worktrees/$WT_PATH_SEG" "$WT_BASE"
    ```
-   On failure (branch or path already exists), append `-2` to both `$WT_BRANCH` and `$WT_PATH_SEG` and retry once. If it still fails, abort with a clear error to the user.
+   On failure (branch or path already exists), append `-2` to both `$WT_BRANCH` and `$WT_PATH_SEG` and retry once. If it still fails, abort with a clear error to the user. **If the retry succeeds and `AUTO_COMMIT=true`, set `AUTO_COMMIT_BRANCH=$WT_BRANCH`** so downstream commit/push/PR/report steps target the renamed branch.
 
 5. `cd ".claude-worktrees/$WT_PATH_SEG"`. All subsequent steps run inside the worktree.
 

--- a/.claude/skills/debug-workflow/SKILL.md
+++ b/.claude/skills/debug-workflow/SKILL.md
@@ -66,7 +66,7 @@ Store `WORKTREE_PATH=""` as the default. It is set to the new worktree's relativ
    ```bash
    git worktree add -b "$WT_BRANCH" ".claude-worktrees/$WT_PATH_SEG" "$WT_BASE"
    ```
-   On failure (branch or path already exists), append `-2` to both `$WT_BRANCH` and `$WT_PATH_SEG` and retry once. If it still fails, abort with a clear error to the user.
+   On failure (branch or path already exists), append `-2` to both `$WT_BRANCH` and `$WT_PATH_SEG` and retry once. If it still fails, abort with a clear error to the user. **If the retry succeeds and `AUTO_COMMIT=true`, set `AUTO_COMMIT_BRANCH=$WT_BRANCH`** so downstream commit/push/PR/report steps target the renamed branch.
 
 5. `cd ".claude-worktrees/$WT_PATH_SEG"`. All subsequent steps run inside the worktree.
 

--- a/.claude/skills/debug-workflow/SKILL.md
+++ b/.claude/skills/debug-workflow/SKILL.md
@@ -31,9 +31,46 @@ Ask: "Enable auto-commit and PR?" (Yes / No) → `AUTO_COMMIT`.
      - Option 2: `<CURRENT_BRANCH>` (current branch)
      - Option 3: Other (enter branch name)
    - Store chosen base as `BASE_BRANCH`.
-   - Run `git checkout -b <AUTO_COMMIT_BRANCH> <BASE_BRANCH>`. On failure append `-2`, retry once.
+   - **Do not create the branch yet** — Step 0.1b performs the actual `git checkout -b` or `git worktree add -b` based on the worktree choice.
 
 **If `AUTO_COMMIT=false`:** `BRANCH_ACTION=none`.
+
+## Step 0.1b: Worktree opt-in and branch creation
+
+Ask: "Run workflow in a new git worktree? (enables running multiple pipelines in parallel in the same project)" (Yes / No) → `USE_WORKTREE`.
+
+Store `WORKTREE_PATH=""` as the default. It is set to the new worktree's relative path only if one is created.
+
+### If `USE_WORKTREE=false`:
+
+- **If `AUTO_COMMIT=true` AND `BRANCH_ACTION=new`**: run `git checkout -b <AUTO_COMMIT_BRANCH> <BASE_BRANCH>`. On failure append `-2` to `AUTO_COMMIT_BRANCH`, retry once.
+- Otherwise: take no action here. Continue to Step 0a.
+
+### If `USE_WORKTREE=true`:
+
+1. **If `AUTO_COMMIT=true` AND `BRANCH_ACTION=current`**: worktrees require a fresh branch (git disallows two worktrees on the same branch). Ask: "Worktree needs a new branch. Switch to a new branch, or skip the worktree and commit on the current branch?"
+   - **"Create new branch"** → set `BRANCH_ACTION=new`. Generate `AUTO_COMMIT_BRANCH=fix/<3-5-word-slug>` from `BUG_DESCRIPTION` if not already generated. Run the same base-branch Q&A as Step 0.1 step 3 to pick `BASE_BRANCH`.
+   - **"Skip worktree"** → set `USE_WORKTREE=false` and fall through to the `USE_WORKTREE=false` branch above.
+
+2. Resolve the worktree branch and base:
+   - **If `AUTO_COMMIT=true`**: `WT_BRANCH=$AUTO_COMMIT_BRANCH`, `WT_BASE=$BASE_BRANCH` (both set in Step 0.1).
+   - **If `AUTO_COMMIT=false`**:
+     - Ask: "Branch name for the worktree?" Suggest `fix/<3-5-word-slug>` derived from `BUG_DESCRIPTION`. Store as `WT_BRANCH`.
+     - Run `git fetch origin` and detect `DEFAULT_BRANCH` (same as Step 0.1 step 3).
+     - Get `CURRENT_BRANCH` if not already set.
+     - Ask: "Which branch should `<WT_BRANCH>` be based on?" with the same three options (default / current / other). Store as `WT_BASE`.
+
+3. Sanitize `$WT_BRANCH` into a filesystem-safe path segment (same rules as Step 0a's `SANITIZED`): replace `/` with `-`, strip non-`[A-Za-z0-9._-]`, trim leading/trailing dashes. Store as `WT_PATH_SEG`.
+
+4. Create the worktree and branch atomically:
+   ```bash
+   git worktree add -b "$WT_BRANCH" ".claude-worktrees/$WT_PATH_SEG" "$WT_BASE"
+   ```
+   On failure (branch or path already exists), append `-2` to both `$WT_BRANCH` and `$WT_PATH_SEG` and retry once. If it still fails, abort with a clear error to the user.
+
+5. `cd ".claude-worktrees/$WT_PATH_SEG"`. All subsequent steps run inside the worktree.
+
+6. Set `WORKTREE_PATH=".claude-worktrees/$WT_PATH_SEG"` for the final report.
 
 ## Step 0a: Resolve TASKS_DIR
 
@@ -324,6 +361,12 @@ Summarize the full debug pipeline run to the user:
   OR
 - Branch: <branch-name>
 - PR: <url or "manual command displayed">
+
+### Worktree
+- [omit this section entirely if `WORKTREE_PATH` is empty]
+  OR
+- Path: <WORKTREE_PATH>
+- Cleanup: `git worktree remove <WORKTREE_PATH>` (run from the original repo root)
 
 ### Next Steps
 - [What the user should do -- e.g., manual verification, deploy, monitor]

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -34,9 +34,46 @@ Ask: "Enable auto-commit and PR?" (Yes / No) → `AUTO_COMMIT`.
      - Option 2: `<CURRENT_BRANCH>` (current branch)
      - Option 3: Other (enter branch name)
    - Store chosen base as `BASE_BRANCH`.
-   - Run `git checkout -b <AUTO_COMMIT_BRANCH> <BASE_BRANCH>`. On failure append `-2`, retry once.
+   - **Do not create the branch yet** — Step 0.1b performs the actual `git checkout -b` or `git worktree add -b` based on the worktree choice.
 
 **If `AUTO_COMMIT=false`:** `BRANCH_ACTION=none`, `COMMIT_MODE=none`.
+
+## Step 0.1b: Worktree opt-in and branch creation
+
+Ask: "Run workflow in a new git worktree? (enables running multiple pipelines in parallel in the same project)" (Yes / No) → `USE_WORKTREE`.
+
+Store `WORKTREE_PATH=""` as the default. It is set to the new worktree's relative path only if one is created.
+
+### If `USE_WORKTREE=false`:
+
+- **If `AUTO_COMMIT=true` AND `BRANCH_ACTION=new`**: run `git checkout -b <AUTO_COMMIT_BRANCH> <BASE_BRANCH>`. On failure append `-2` to `AUTO_COMMIT_BRANCH`, retry once.
+- Otherwise: take no action here. Continue to Step 0.2.
+
+### If `USE_WORKTREE=true`:
+
+1. **If `AUTO_COMMIT=true` AND `BRANCH_ACTION=current`**: worktrees require a fresh branch (git disallows two worktrees on the same branch). Ask: "Worktree needs a new branch. Switch to a new branch, or skip the worktree and commit on the current branch?"
+   - **"Create new branch"** → set `BRANCH_ACTION=new`. Generate `AUTO_COMMIT_BRANCH=refactor/<3-5-word-slug>` from `$ARGUMENTS` if not already generated. Run the same base-branch Q&A as Step 0.1 step 4 to pick `BASE_BRANCH`.
+   - **"Skip worktree"** → set `USE_WORKTREE=false` and fall through to the `USE_WORKTREE=false` branch above.
+
+2. Resolve the worktree branch and base:
+   - **If `AUTO_COMMIT=true`**: `WT_BRANCH=$AUTO_COMMIT_BRANCH`, `WT_BASE=$BASE_BRANCH` (both set in Step 0.1).
+   - **If `AUTO_COMMIT=false`**:
+     - Ask: "Branch name for the worktree?" Suggest `refactor/<3-5-word-slug>` derived from `$ARGUMENTS`. Store as `WT_BRANCH`.
+     - Run `git fetch origin` and detect `DEFAULT_BRANCH` (same as Step 0.1 step 4).
+     - Get `CURRENT_BRANCH` if not already set.
+     - Ask: "Which branch should `<WT_BRANCH>` be based on?" with the same three options (default / current / other). Store as `WT_BASE`.
+
+3. Sanitize `$WT_BRANCH` into a filesystem-safe path segment (same rules as Step 0a's `SANITIZED`): replace `/` with `-`, strip non-`[A-Za-z0-9._-]`, trim leading/trailing dashes. Store as `WT_PATH_SEG`.
+
+4. Create the worktree and branch atomically:
+   ```bash
+   git worktree add -b "$WT_BRANCH" ".claude-worktrees/$WT_PATH_SEG" "$WT_BASE"
+   ```
+   On failure (branch or path already exists), append `-2` to both `$WT_BRANCH` and `$WT_PATH_SEG` and retry once. If it still fails, abort with a clear error to the user.
+
+5. `cd ".claude-worktrees/$WT_PATH_SEG"`. All subsequent steps run inside the worktree.
+
+6. Set `WORKTREE_PATH=".claude-worktrees/$WT_PATH_SEG"` for the final report.
 
 ## Step 0.2: Orchestration Mode Selection
 
@@ -321,6 +358,12 @@ Check if `$TASKS_DIR/execution-metrics.md` exists (produced by the orchestrator)
   OR
 - Branch: <branch-name>
 - PR: <url or "manual command displayed">
+
+### Worktree
+- [omit this section entirely if `WORKTREE_PATH` is empty]
+  OR
+- Path: <WORKTREE_PATH>
+- Cleanup: `git worktree remove <WORKTREE_PATH>` (run from the original repo root)
 
 ### Next Steps
 - [e.g., review the changes, run manual tests, address any regressions]

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -69,7 +69,7 @@ Store `WORKTREE_PATH=""` as the default. It is set to the new worktree's relativ
    ```bash
    git worktree add -b "$WT_BRANCH" ".claude-worktrees/$WT_PATH_SEG" "$WT_BASE"
    ```
-   On failure (branch or path already exists), append `-2` to both `$WT_BRANCH` and `$WT_PATH_SEG` and retry once. If it still fails, abort with a clear error to the user.
+   On failure (branch or path already exists), append `-2` to both `$WT_BRANCH` and `$WT_PATH_SEG` and retry once. If it still fails, abort with a clear error to the user. **If the retry succeeds and `AUTO_COMMIT=true`, set `AUTO_COMMIT_BRANCH=$WT_BRANCH`** so downstream commit/push/PR/report steps target the renamed branch.
 
 5. `cd ".claude-worktrees/$WT_PATH_SEG"`. All subsequent steps run inside the worktree.
 


### PR DESCRIPTION
## Summary

Each of `/build`, `/refactor`, `/debug-workflow` now asks **"Run in a new git worktree?"** right after the auto-commit opt-in. When enabled, the workflow creates `.claude-worktrees/<sanitized-branch>/` via `git worktree add -b` and `cd`s into it, so multiple pipelines can run in parallel in the same project without colliding on the working tree.

## Changes

- New **Step 0.1b** inserted after Step 0.1 in all three skills. Consolidates branch creation:
  - `USE_WORKTREE=false` → `git checkout -b <branch> <base>` (existing behavior)
  - `USE_WORKTREE=true` → `git worktree add -b <branch> .claude-worktrees/<slug> <base>` and `cd` into it
- `git checkout -b` is removed from Step 0.1 itself — Step 0.1b handles both paths.
- When `AUTO_COMMIT=false` + `USE_WORKTREE=true`: the skill prompts for a branch name (default `feat/` / `refactor/` / `fix/` slug) and a base branch using the same three-option Q&A the auto-commit flow uses.
- Edge case: `AUTO_COMMIT=true` + `BRANCH_ACTION=current` + `USE_WORKTREE=true` — git disallows two worktrees on the same branch. Skill asks the user to either switch to a new branch or skip the worktree.
- Collision handling: if the target path or branch already exists, append `-2` and retry once.
- Final reports now include a `Worktree` section with the path and a `git worktree remove` cleanup hint (omitted when no worktree was created).

`/qa` is **not** touched — this change is scoped to skills that have the auto-commit flow.

## Why

`tasks/<branch>/` and `qa-output/<branch>/` are already branch-scoped, so artifacts don't collide across parallel runs. But the working tree was still shared. Worktree opt-in closes that last gap: now you can start `/build X` on one branch and `/refactor Y` on another in the same repo without either clobbering the other's checkout.

## Test plan

- [ ] `/build <tiny PRD>` with `AUTO_COMMIT=yes` + `USE_WORKTREE=yes` — verify worktree at `.claude-worktrees/feat-<slug>/`, session CWD changes, `tasks/feat-<slug>/` created inside the worktree, squash commit lands on the new branch, original checkout is untouched.
- [ ] `/refactor <target>` and `/build <prd>` simultaneously in two sessions, both with worktree on — both should proceed with no `.git/index.lock` or filesystem collisions.
- [ ] `/debug-workflow <bug>` with auto-commit off + worktree on — prompts for slug, creates `fix/<slug>` worktree, debug artifacts go to its `tasks/fix-<slug>/`.
- [ ] `/build <prd>` with auto-commit on + worktree **off** — regression check; behavior unchanged from today.
- [ ] Collision: pre-create `.claude-worktrees/feat-foo/`, run `/build` that would generate that slug, expect fallback to `feat-foo-2`.
- [ ] Final report shows the worktree line + cleanup hint when worktree was created; omits it otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deferred branch creation until later in the flow and added an opt-in worktree mode so tasks can run in an isolated worktree when desired.
  * Worktree flow prompts for branch/base names when needed, sanitizes paths, retries worktree creation once on failure, and updates downstream branch targeting.
  * Final reports now include a conditional “Worktree” section with path and cleanup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->