### PR TITLE
feat: add status line (model | project | branch | ctx %)

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# statusline.sh — Claude Code status line.
+# Reads session JSON on stdin, prints one line: model | project | folder | branch | ctx%.
+#
+# Wired in ~/.claude/settings.json under "statusLine":
+#   { "type": "command", "command": "bash ~/.claude/statusline.sh", "padding": 0 }
+
+set -u
+
+input=$(cat)
+
+# --- JSON access (jq preferred, python3 fallback) ---
+if command -v jq &>/dev/null; then
+  _get() { printf '%s' "$input" | jq -r "$1 // empty" 2>/dev/null; }
+else
+  _get() {
+    printf '%s' "$input" | python3 -c "
+import sys, json
+keys = sys.argv[1].lstrip('.').split('.')
+try:
+    d = json.load(sys.stdin)
+    for k in keys:
+        d = d.get(k) if isinstance(d, dict) else None
+    if d not in (None, False):
+        print(d)
+except Exception:
+    pass
+" "$1" 2>/dev/null
+  }
+fi
+
+model=$(_get '.model.display_name')
+project_dir=$(_get '.workspace.project_dir')
+current_dir=$(_get '.workspace.current_dir')
+transcript=$(_get '.transcript_path')
+
+# --- Project name + path relative to project root ---
+project_name=""
+rel_dir=""
+if [ -n "$project_dir" ]; then
+  project_name=$(basename "$project_dir")
+  if [ -n "$current_dir" ] && [ "$current_dir" != "$project_dir" ]; then
+    rel_dir="${current_dir#"$project_dir"/}"
+  fi
+fi
+
+# --- Git branch ---
+branch=""
+if [ -n "$current_dir" ] && [ -d "$current_dir" ]; then
+  branch=$(git -C "$current_dir" branch --show-current 2>/dev/null || true)
+  if [ -z "$branch" ]; then
+    # Detached HEAD — show short SHA
+    branch=$(git -C "$current_dir" rev-parse --short HEAD 2>/dev/null || true)
+    [ -n "$branch" ] && branch="@$branch"
+  fi
+fi
+
+# --- Context window % (parses latest usage from transcript JSONL) ---
+ctx_pct=""
+if [ -n "$transcript" ] && [ -f "$transcript" ] && command -v python3 &>/dev/null; then
+  ctx_pct=$(python3 - "$transcript" "${model:-}" <<'PYEOF' 2>/dev/null
+import sys, json
+path, model = sys.argv[1], sys.argv[2]
+last = None
+try:
+    with open(path) as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+                u = obj.get("message", {}).get("usage")
+                if u:
+                    last = u
+            except Exception:
+                pass
+except Exception:
+    sys.exit(0)
+if not last:
+    sys.exit(0)
+total = (last.get("input_tokens") or 0) \
+      + (last.get("cache_read_input_tokens") or 0) \
+      + (last.get("cache_creation_input_tokens") or 0)
+ctx_max = 1_000_000 if "1M" in (model or "") else 200_000
+print(total * 100 // ctx_max)
+PYEOF
+)
+fi
+
+# --- Colors (ANSI — Claude Code statuslines render these) ---
+DIM=$'\033[2m'
+RESET=$'\033[0m'
+CYAN=$'\033[36m'
+GREEN=$'\033[32m'
+MAGENTA=$'\033[35m'
+YELLOW=$'\033[33m'
+RED=$'\033[31m'
+
+# --- Assemble output ---
+parts=()
+[ -n "$model" ] && parts+=("${MAGENTA}${model}${RESET}")
+[ -n "$project_name" ] && parts+=("${CYAN}${project_name}${RESET}")
+[ -n "$rel_dir" ] && parts+=("${DIM}${rel_dir}${RESET}")
+[ -n "$branch" ] && parts+=("${GREEN}(${branch})${RESET}")
+
+if [ -n "$ctx_pct" ] && [ "$ctx_pct" -ge 0 ] 2>/dev/null; then
+  if [ "$ctx_pct" -ge 90 ] 2>/dev/null; then
+    parts+=("${RED}ctx ${ctx_pct}%${RESET}")
+  elif [ "$ctx_pct" -ge 70 ] 2>/dev/null; then
+    parts+=("${YELLOW}ctx ${ctx_pct}%${RESET}")
+  else
+    parts+=("${DIM}ctx ${ctx_pct}%${RESET}")
+  fi
+fi
+
+sep=" ${DIM}|${RESET} "
+out=""
+for i in "${!parts[@]}"; do
+  if [ "$i" -eq 0 ]; then
+    out="${parts[$i]}"
+  else
+    out="${out}${sep}${parts[$i]}"
+  fi
+done
+printf '%s' "$out"

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# statusline.sh — Claude Code status line.
-# Reads session JSON on stdin, prints one line: model | project | folder | branch | ctx%.
+# statusline.sh — Agnoster-style Claude Code status line.
+# Reads session JSON on stdin, prints powerline segments:
+#   model | project | folder | branch | ctx %
 #
 # Wired in ~/.claude/settings.json under "statusLine":
 #   { "type": "command", "command": "bash ~/.claude/statusline.sh", "padding": 0 }
+#
+# Requires a Powerline / Nerd Font in the terminal for the segment arrows
+# and branch glyph to render. Without one, glyphs appear as boxes/question marks.
 
 set -u
 
@@ -34,28 +38,38 @@ project_dir=$(_get '.workspace.project_dir')
 current_dir=$(_get '.workspace.current_dir')
 transcript=$(_get '.transcript_path')
 
-# --- Project name + path relative to project root ---
+# --- Project name + folder relative to project root ---
 project_name=""
 rel_dir=""
 if [ -n "$project_dir" ]; then
   project_name=$(basename "$project_dir")
   if [ -n "$current_dir" ] && [ "$current_dir" != "$project_dir" ]; then
-    rel_dir="${current_dir#"$project_dir"/}"
+    if [[ "$current_dir" == "$project_dir"/* ]]; then
+      rel_dir="${current_dir#"$project_dir"/}"
+    else
+      rel_dir=$(basename "$current_dir")
+    fi
   fi
 fi
 
-# --- Git branch ---
+# --- Git branch + dirty flag ---
 branch=""
+dirty=0
 if [ -n "$current_dir" ] && [ -d "$current_dir" ]; then
   branch=$(git -C "$current_dir" branch --show-current 2>/dev/null || true)
   if [ -z "$branch" ]; then
-    # Detached HEAD — show short SHA
-    branch=$(git -C "$current_dir" rev-parse --short HEAD 2>/dev/null || true)
-    [ -n "$branch" ] && branch="@$branch"
+    sha=$(git -C "$current_dir" rev-parse --short HEAD 2>/dev/null || true)
+    [ -n "$sha" ] && branch="@$sha"
+  fi
+  if [ -n "$branch" ]; then
+    if ! git -C "$current_dir" diff --quiet 2>/dev/null \
+       || ! git -C "$current_dir" diff --cached --quiet 2>/dev/null; then
+      dirty=1
+    fi
   fi
 fi
 
-# --- Context window % (parses latest usage from transcript JSONL) ---
+# --- Context window % from transcript ---
 ctx_pct=""
 if [ -n "$transcript" ] && [ -f "$transcript" ] && command -v python3 &>/dev/null; then
   ctx_pct=$(python3 - "$transcript" "${model:-}" <<'PYEOF' 2>/dev/null
@@ -85,39 +99,59 @@ PYEOF
 )
 fi
 
-# --- Colors (ANSI — Claude Code statuslines render these) ---
-DIM=$'\033[2m'
+# --- Powerline glyphs (require Nerd Font / Powerline-patched font) ---
+ARROW=$''   # right-pointing solid triangle
+BRANCH=$''  # branch glyph
 RESET=$'\033[0m'
-CYAN=$'\033[36m'
-GREEN=$'\033[32m'
-MAGENTA=$'\033[35m'
-YELLOW=$'\033[33m'
-RED=$'\033[31m'
 
-# --- Assemble output ---
-parts=()
-[ -n "$model" ] && parts+=("${MAGENTA}${model}${RESET}")
-[ -n "$project_name" ] && parts+=("${CYAN}${project_name}${RESET}")
-[ -n "$rel_dir" ] && parts+=("${DIM}${rel_dir}${RESET}")
-[ -n "$branch" ] && parts+=("${GREEN}(${branch})${RESET}")
+# --- 256-color palette (agnoster-inspired) ---
+BG_MODEL=54;       FG_MODEL=255    # purple bg, white text
+BG_PROJ=31;        FG_PROJ=255     # teal bg, white text
+BG_DIR=240;        FG_DIR=252      # gray bg, light gray text
+BG_BRANCH_OK=64;   FG_BRANCH_OK=235    # green bg, near-black text
+BG_BRANCH_DIRTY=166; FG_BRANCH_DIRTY=235 # orange bg, near-black text
+BG_CTX_OK=236;     FG_CTX_OK=245   # near-black bg, mid-gray text
+BG_CTX_WARN=178;   FG_CTX_WARN=235 # gold bg, near-black text
+BG_CTX_DANGER=124; FG_CTX_DANGER=255 # red bg, white text
 
-if [ -n "$ctx_pct" ] && [ "$ctx_pct" -ge 0 ] 2>/dev/null; then
-  if [ "$ctx_pct" -ge 90 ] 2>/dev/null; then
-    parts+=("${RED}ctx ${ctx_pct}%${RESET}")
-  elif [ "$ctx_pct" -ge 70 ] 2>/dev/null; then
-    parts+=("${YELLOW}ctx ${ctx_pct}%${RESET}")
+# --- Segment renderer: builds a continuous powerline strip ---
+prev_bg=""
+out=""
+seg() {
+  local bg=$1 fg=$2 text=$3
+  [ -z "$text" ] && return
+  if [ -n "$prev_bg" ]; then
+    out+=$'\033[38;5;'"$prev_bg"$';48;5;'"$bg"$'m'"$ARROW"
+  fi
+  out+=$'\033[38;5;'"$fg"$';48;5;'"$bg"$'m '"$text"' '
+  prev_bg=$bg
+}
+
+[ -n "$model" ]        && seg "$BG_MODEL" "$FG_MODEL" "$model"
+[ -n "$project_name" ] && seg "$BG_PROJ"  "$FG_PROJ"  "$project_name"
+[ -n "$rel_dir" ]      && seg "$BG_DIR"   "$FG_DIR"   "$rel_dir"
+
+if [ -n "$branch" ]; then
+  if [ "$dirty" -eq 1 ]; then
+    seg "$BG_BRANCH_DIRTY" "$FG_BRANCH_DIRTY" "$BRANCH $branch *"
   else
-    parts+=("${DIM}ctx ${ctx_pct}%${RESET}")
+    seg "$BG_BRANCH_OK" "$FG_BRANCH_OK" "$BRANCH $branch"
   fi
 fi
 
-sep=" ${DIM}|${RESET} "
-out=""
-for i in "${!parts[@]}"; do
-  if [ "$i" -eq 0 ]; then
-    out="${parts[$i]}"
+if [ -n "$ctx_pct" ] && [ "$ctx_pct" -ge 0 ] 2>/dev/null; then
+  if [ "$ctx_pct" -ge 90 ] 2>/dev/null; then
+    seg "$BG_CTX_DANGER" "$FG_CTX_DANGER" "ctx ${ctx_pct}%"
+  elif [ "$ctx_pct" -ge 70 ] 2>/dev/null; then
+    seg "$BG_CTX_WARN" "$FG_CTX_WARN" "ctx ${ctx_pct}%"
   else
-    out="${out}${sep}${parts[$i]}"
+    seg "$BG_CTX_OK" "$FG_CTX_OK" "ctx ${ctx_pct}%"
   fi
-done
+fi
+
+# Closing arrow: previous bg as fg, default bg.
+if [ -n "$prev_bg" ]; then
+  out+=$'\033[0m\033[38;5;'"$prev_bg"$'m'"$ARROW""$RESET"
+fi
+
 printf '%s' "$out"

--- a/auto-update.sh
+++ b/auto-update.sh
@@ -94,6 +94,7 @@ CLAUDE_FILES=(
   ".claude/skills/init-claude-setup/SKILL.md"
   ".claude/skills/qa/SKILL.md"
   ".claude/skills/refactor/SKILL.md"
+  ".claude/statusline.sh"
 )
 
 for file in "${CLAUDE_FILES[@]}"; do
@@ -102,6 +103,8 @@ for file in "${CLAUDE_FILES[@]}"; do
   if [ -f "$src" ]; then
     mkdir -p "$(dirname "$dest")"
     cp "$src" "$dest"
+    # Keep shell scripts executable (statusline.sh, hooks/*.sh)
+    case "$dest" in *.sh) chmod +x "$dest" 2>/dev/null || true ;; esac
   fi
 done
 
@@ -109,6 +112,31 @@ done
 if [ -f "$CLONE_DIR/auto-update.sh" ]; then
   cp "$CLONE_DIR/auto-update.sh" "$HOME/.claude/auto-update.sh"
   chmod +x "$HOME/.claude/auto-update.sh"
+fi
+
+# --- Status line: idempotently wire up if not already configured ---
+statusline_settings="$HOME/.claude/settings.json"
+if [ -f "$HOME/.claude/statusline.sh" ] && \
+   ! { [ -f "$statusline_settings" ] && grep -q '"statusLine"' "$statusline_settings" 2>/dev/null; }; then
+  mkdir -p "$HOME/.claude"
+  sl_cfg='{"type":"command","command":"bash ~/.claude/statusline.sh","padding":0}'
+  if [ ! -f "$statusline_settings" ]; then
+    python3 -c "
+import json, sys
+print(json.dumps({'statusLine': json.loads(sys.argv[1])}, indent=2))
+" "$sl_cfg" > "$statusline_settings" 2>>"$LOG_FILE" && \
+      _log "[STATUSLINE] Created settings.json with statusLine config"
+  else
+    sl_merged=$(python3 -c "
+import json, sys
+with open(sys.argv[2]) as f:
+    data = json.load(f)
+data['statusLine'] = json.loads(sys.argv[1])
+print(json.dumps(data, indent=2))
+" "$sl_cfg" "$statusline_settings" 2>>"$LOG_FILE") && \
+      echo "$sl_merged" > "$statusline_settings" && \
+      _log "[STATUSLINE] Added statusLine to settings.json"
+  fi
 fi
 
 # --- Token Reducer ---

--- a/setup.sh
+++ b/setup.sh
@@ -187,6 +187,7 @@ CLAUDE_FILES=(
   ".claude/skills/qa/SKILL.md"
   ".claude/skills/refactor/SKILL.md"
   ".claude/hooks/token-reducer-nudge.sh"
+  ".claude/statusline.sh"
 )
 
 DEVCONTAINER_FILES=(
@@ -828,6 +829,69 @@ _remove_nudge_hook() {
   touch "$HOME/.claude/.token-reducer-nudged"
 }
 
+# --- Status line: copy script and merge config into ~/.claude/settings.json ---
+_install_statusline_config() {
+  local script_dest="$HOME/.claude/statusline.sh"
+  local settings_file="$HOME/.claude/settings.json"
+
+  # The script itself is already copied via CLAUDE_FILES — just chmod it.
+  if [ -f "$script_dest" ]; then
+    chmod +x "$script_dest" 2>/dev/null || true
+  fi
+
+  mkdir -p "$HOME/.claude"
+
+  # If statusLine is already configured (any value), don't clobber it.
+  if [ -f "$settings_file" ] && grep -q '"statusLine"' "$settings_file" 2>/dev/null; then
+    return 0
+  fi
+
+  local cfg='{"type":"command","command":"bash ~/.claude/statusline.sh","padding":0}'
+
+  if [ ! -f "$settings_file" ]; then
+    python3 -c "
+import json, sys
+cfg = json.loads(sys.argv[1])
+print(json.dumps({'statusLine': cfg}, indent=2))
+" "$cfg" > "$settings_file" 2>/dev/null && {
+      echo "  Created ~/.claude/settings.json with statusLine config."
+      return 0
+    }
+    if command -v jq &>/dev/null; then
+      echo "$cfg" | jq '{statusLine: .}' > "$settings_file" 2>/dev/null && {
+        echo "  Created ~/.claude/settings.json with statusLine config."
+        return 0
+      }
+    fi
+  else
+    local merged
+    merged=$(python3 -c "
+import json, sys
+cfg = json.loads(sys.argv[1])
+with open(sys.argv[2]) as f:
+    data = json.load(f)
+data['statusLine'] = cfg
+print(json.dumps(data, indent=2))
+" "$cfg" "$settings_file" 2>/dev/null) && {
+      echo "$merged" > "$settings_file"
+      echo "  Added statusLine to ~/.claude/settings.json."
+      return 0
+    }
+    if command -v jq &>/dev/null; then
+      merged=$(jq --argjson cfg "$cfg" '.statusLine = $cfg' "$settings_file" 2>/dev/null) && {
+        echo "$merged" > "$settings_file"
+        echo "  Added statusLine to ~/.claude/settings.json."
+        return 0
+      }
+    fi
+  fi
+
+  echo "  Warning: could not wire up statusLine (python3 and jq unavailable)."
+  echo "  Add manually to ~/.claude/settings.json:"
+  echo "    \"statusLine\": $cfg"
+  return 1
+}
+
 _setup_token_reducer_pack() {
   echo "=== Token Reducer Pack ==="
   echo ""
@@ -978,6 +1042,12 @@ perform_global_install() {
       fi
     fi
   fi
+
+  # --- Status line ---
+  echo "=== Status line ==="
+  echo ""
+  _install_statusline_config
+  echo ""
 
   # --- Token Reducer Pack ---
   _setup_token_reducer_pack


### PR DESCRIPTION
## Summary
- Adds `.claude/statusline.sh` — shows model, project name, current folder (relative to project), git branch, and context-window % parsed from the transcript JSONL
- `setup.sh` now copies it during global install/update and merges `statusLine` into `~/.claude/settings.json` (preserves existing keys; skips if already configured)
- `auto-update.sh` syncs the script on every tick, applies `chmod +x` to any `*.sh` it copies, and idempotently wires the `statusLine` config so existing PCs pick it up automatically

## Test plan
- [x] Smoke-test `statusline.sh` with mock JSON (model + project + subdir + branch render correctly)
- [x] Verify context % parsing against a real `~/.claude/projects/.../*.jsonl` transcript
- [x] `bash -n` clean on all three scripts
- [x] Wired up on dev PC — `~/.claude/settings.json` gained `statusLine` key, other keys preserved
- [ ] Auto-update tick on a second PC picks up the new file + merges the config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a status line indicator displaying model name, workspace project path, Git branch information, and real-time context window usage estimates with color-coded formatting.

* **Chores**
  * Integrated automated configuration and deployment of the status line feature into setup and auto-update processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->