### PR TITLE
feat: pre-build grilling skills (/grill-me, /grill-with-docs)

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -18,6 +18,36 @@ $ARGUMENTS
 - If `$ARGUMENTS` starts with or contains `--brainstorm`, set `BRAINSTORM=true` and strip `--brainstorm` to get the clean PRD content.
 - Otherwise, `BRAINSTORM=false` and the full arguments are the PRD content.
 
+## Step 0.05: PRD adequacy check
+
+Before any planning, gauge whether the input PRD has enough substance for the planner to work with. Read the parsed PRD content (or the file at the path provided in `$ARGUMENTS`).
+
+**Skip this step entirely if `--brainstorm` was passed.** Brainstorm mode is itself a form of pre-planning sharpening — the user has explicitly asked for options to be proposed.
+
+**Treat the PRD as underspecified if any are true:**
+- It is shorter than ~3 sentences
+- It expresses a desire ("I want to...", "we should...") without naming user-facing behavior, scope, or success criteria
+- It contains explicit hedges ("not sure if...", "maybe...", "something like...")
+- The current chat session has no prior context indicating the design has been worked through (no prior grilling, no design doc shared, no answered clarifying questions)
+
+**If underspecified:**
+
+1. Detect domain docs at the repo root: check whether `CONTEXT.md` (single-context) or `CONTEXT-MAP.md` (multi-context) exists.
+
+2. Use `AskUserQuestion`:
+   - Question: "The PRD is sparse. Grilling first usually catches misalignment cheaper than the planner does. How do you want to proceed?"
+   - Options:
+     - **"Run `/grill-with-docs` first"** (only offer when `CONTEXT.md` or `CONTEXT-MAP.md` was detected) — stop the build pipeline; user re-runs `/build` after grilling
+     - **"Run `/grill-me` first"** — stop the build pipeline; user re-runs `/build` after grilling
+     - **"Continue anyway"** — proceed; the planner's discovery phase will pick up the slack
+     - **"Switch to `--brainstorm`"** — re-run `/build` with the `--brainstorm` flag to get design options proposed instead
+
+3. If the user picks a grill or brainstorm option, exit cleanly with a message like: "Stopping `/build`. Re-run with the sharpened PRD when grilling is complete." Do not invoke the chosen skill yourself — the user re-invokes manually so the grilling session has a clean context.
+
+4. If the user picks "Continue anyway", proceed to Step 0.1.
+
+**If the PRD is adequate:** proceed directly to Step 0.1.
+
 ## Step 0.1: Auto-commit opt-in
 
 Ask: "Enable auto-commit and PR?" (Yes / No) → `AUTO_COMMIT`.

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when the user wants to stress-test a plan, get grilled on their design, or mentions "grill me". Run BEFORE /build when a feature idea is fuzzy and a PRD doesn't yet exist.
+---
+
+Interview the user relentlessly about every aspect of this plan until you reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, propose your recommended answer so the user can accept, override, or refine.
+
+## Rules
+
+- **One question at a time.** Wait for the user's answer before moving on. Do not batch.
+- **Recommend an answer with each question.** "I'd default to X because Y — agree?" Forces the user to commit or counter; pure open-ended questions stall.
+- **If a question can be answered by exploring the codebase, explore the codebase instead.** Don't ask the user about things that can be read.
+- **Keep questions short and concrete.** No multi-paragraph preambles. The user is here to be grilled, not lectured.
+- **Stop when you've reached the leaves.** When every branch of the decision tree is resolved or explicitly deferred, summarize the decisions and offer to convert them into a PRD via `/build` (or hand off to `/grill-with-docs` if the project has a `CONTEXT.md`).
+
+## Output at the end
+
+A short bulleted list of the decisions reached, plus any explicitly-deferred questions. The user will paste this into `/build` (or you can offer to invoke it directly).

--- a/.claude/skills/grill-with-docs/ADR-FORMAT.md
+++ b/.claude/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,77 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A concise description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**
+- An **Invoice** belongs to exactly one **Customer**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when the user wants to stress-test a plan against the project's language and documented decisions. Run BEFORE /build on non-trivial features in repos that have (or should have) a CONTEXT.md.
+---
+
+Interview the user relentlessly about every aspect of this plan until you reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, propose your recommended answer.
+
+Ask one question at a time, waiting for an answer before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead of asking.
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+## Output at the end
+
+A short bulleted summary of the resolved decisions and any deferred questions, plus a list of the files updated (`CONTEXT.md`, new ADRs). Then offer to invoke `/build` with the resolved plan as the PRD seed.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A template for setting up Claude Code (agents, skills, memory) in any project. U
 
 | Pipeline | What it does |
 |---|---|
+| [`/grill-me`, `/grill-with-docs`](#pre-build-grilling-grill-me-grill-with-docs) | Fuzzy idea → relentless interview → sharpened plan (run before `/build`) |
 | [`/build`](#the-build-pipeline-build) | PRD → plan → **plan review** → parallel implementation → code review |
 | [`/debug-workflow`](#the-debug-pipeline-debug-workflow) | Bug report → investigate → diagnose → TDD fix → review |
 | [`/refactor`](#the-refactor-pipeline-refactor) | Target → audit → (write tests) → refactor → behavior-preservation review |
@@ -204,6 +205,8 @@ Review `.claude/settings.local.json` to adjust permissions for your project.
 │   ├── build/SKILL.md                    # /build — plan → review-plan → implement → review
 │   ├── craft-pr/SKILL.md                 # /craft-pr — generates PR description from tasks + diff
 │   ├── debug-workflow/SKILL.md           # /debug-workflow — investigate → diagnose → TDD fix → review
+│   ├── grill-me/SKILL.md                 # /grill-me — pre-PRD interview to align on a fuzzy plan
+│   ├── grill-with-docs/                  # /grill-with-docs — grill + update CONTEXT.md/ADRs inline
 │   ├── init-claude-setup/SKILL.md        # /init-claude-setup — project-level init (gitignore, settings)
 │   ├── qa/SKILL.md                       # /qa — exploratory QA via browser + Playwright E2E tests
 │   └── refactor/SKILL.md                 # /refactor — audit → plan → (tests) → implement → review
@@ -229,10 +232,12 @@ The `/build` skill orchestrates the full feature implementation lifecycle. Paste
 ### How it works
 
 ```
-PRD → [Plan] → [User Q&A] → [Review Plan] → [Implement] → [Test] → [Review Code] → Done
+PRD → [Adequacy check] → [Plan] → [User Q&A] → [Review Plan] → [Implement] → [Test] → [Review Code] → Done
 ```
 
 All outputs land in `tasks/<branch>/` (see [Branch-scoped work directories](#branch-scoped-work-directories)).
+
+Before any planning, `/build` checks whether the input PRD has enough substance. If it's a one-liner or full of hedges, you're offered three escapes: run [`/grill-me`](#pre-build-grilling-grill-me-grill-with-docs) (or [`/grill-with-docs`](#pre-build-grilling-grill-me-grill-with-docs) if the repo has a `CONTEXT.md`) first, switch to `--brainstorm` mode, or continue anyway. Skipped automatically when `--brainstorm` is already passed.
 
 #### Step 1: Two-Phase Planning (with user input)
 
@@ -315,6 +320,24 @@ Even when TDD mode is not enabled, the pipeline is test-aware:
 - The `task-implementer` discovers and runs existing tests related to modified files
 - The build pipeline runs the project's full test suite after implementation (Step 2c)
 - The `code-reviewer` evaluates test coverage as a standard quality check
+
+## Pre-build grilling (`/grill-me`, `/grill-with-docs`)
+
+The most common reason a build goes sideways isn't bad code — it's that the PRD didn't say what the user actually wanted. These two skills sit *before* `/build` and force alignment up front.
+
+- **`/grill-me`** — interview-style skill that walks down every branch of a plan one question at a time, recommending an answer for each. Use when you have a fuzzy idea and no PRD yet.
+- **`/grill-with-docs`** — same shape, but also reads the project's `CONTEXT.md` (and `docs/adr/`) and challenges your terminology against the documented domain language. Updates `CONTEXT.md` and creates ADRs inline as decisions crystallise. Use when the project has (or should have) a domain glossary.
+
+`CONTEXT.md` is a per-repo file capturing the domain language: bolded canonical terms, aliases to avoid, relationships, and an example dialogue. ADRs live in `docs/adr/` and capture the *why* of hard-to-reverse decisions. Both files are created lazily — the skill writes to them only when there's something to record. See [`CONTEXT-FORMAT.md`](.claude/skills/grill-with-docs/CONTEXT-FORMAT.md) and [`ADR-FORMAT.md`](.claude/skills/grill-with-docs/ADR-FORMAT.md) for the formats.
+
+```bash
+/grill-me                 # I want to add comment threading to the wiki
+/grill-with-docs          # same, but also evolve CONTEXT.md/ADRs
+```
+
+When `/build` detects a sparse PRD it offers these as the recommended next step (Step 0.05 in `build/SKILL.md`).
+
+Credit: adapted from [mattpocock/skills](https://github.com/mattpocock/skills).
 
 ## The Debug Pipeline (`/debug-workflow`)
 


### PR DESCRIPTION
## Summary

- Adds `/grill-me` and `/grill-with-docs` (adapted from [mattpocock/skills](https://github.com/mattpocock/skills)) — interview-style skills that align you with the agent before `/build` runs. `/grill-me` is generic; `/grill-with-docs` additionally reads `CONTEXT.md` and `docs/adr/` to challenge terminology against the project's domain language and updates those files inline as decisions crystallise.
- `/build` now runs a PRD adequacy check (Step 0.05) before any planning. Sparse PRDs trigger an `AskUserQuestion` with four options: run `/grill-with-docs` first (offered only when `CONTEXT.md`/`CONTEXT-MAP.md` exists), run `/grill-me` first, switch to `--brainstorm`, or continue anyway. Auto-skipped when `--brainstorm` is already passed.
- Documents the `CONTEXT.md` and ADR conventions for repos that want a domain glossary, with format docs bundled in `.claude/skills/grill-with-docs/`.

## Test plan

- [ ] Run `/grill-me` against a fuzzy idea — verify it asks one question at a time and recommends an answer per question.
- [ ] Run `/grill-with-docs` in a repo that has a `CONTEXT.md` — verify it reads the glossary, challenges terminology that conflicts with it, and updates the file inline as terms get resolved.
- [ ] Run `/grill-with-docs` in a repo without a `CONTEXT.md` — verify it creates one lazily on the first resolved term.
- [ ] Run `/build` with a one-liner PRD — verify Step 0.05 fires and presents the four options. The "/grill-with-docs" option should only appear when `CONTEXT.md` is present.
- [ ] Run `/build --brainstorm "..."` — verify Step 0.05 is skipped entirely.
- [ ] Run `/build` with a substantive multi-paragraph PRD — verify Step 0.05 doesn't fire and the pipeline proceeds straight to Step 0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/grill-me`: Interactive interview-style skill to refine requirements through guided questioning
  * Added `/grill-with-docs`: Domain-aware planning skill with context alignment and architecture decision recording
  * Introduced PRD validation that recommends planning skills when requirements need refinement

* **Documentation**
  * Added Architecture Decision Record (ADR) and project context format specifications
  * Updated pipeline documentation with new pre-planning workflow options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->