### PR TITLE
feat: reduce /build and /refactor token cost (~50%)

### DIFF
--- a/.claude/agents/agent-teams-orchestrator.md
+++ b/.claude/agents/agent-teams-orchestrator.md
@@ -161,7 +161,7 @@ Additional context:
 - Only touch the files specified in the task
 - After implementing, verify your changes by re-reading modified files
 
-When done: write your Implementation Notes (decisions, deviations, trade-offs, risks) to `$TASKS_DIR/notes/task-NN.md` (NN = zero-padded task number from the task file name). Return only a brief status: what you implemented, files changed, any issues encountered. Do NOT include the Implementation Notes block in your return — they live in the file. Bloated returns inflate the orchestrator's context across N parallel teammates.
+When done: write Implementation Notes (decisions, deviations, trade-offs, risks) to `$TASKS_DIR/notes/task-NN.md` for each completed task (NN = zero-padded task number from each task file's name; for batched runs that cover multiple tasks, write one file per task — never aggregate). Return only a brief status: what you implemented, files changed, any issues encountered. Do NOT include the Implementation Notes block in your return — they live in files. Bloated returns inflate the orchestrator's context across N parallel teammates.
 ```
 
 For **batched tasks**, list all task files in the prompt and specify the order to implement them.

--- a/.claude/agents/agent-teams-orchestrator.md
+++ b/.claude/agents/agent-teams-orchestrator.md
@@ -224,7 +224,7 @@ After all waves are done:
    - List `$TASKS_DIR/notes/task-*.md` (sorted by filename, which is task number)
    - Concatenate the contents into `$TASKS_DIR/implementation-notes.md` with a `# Implementation Notes` header at the top
    - If `$TASKS_DIR/notes/` is empty or missing, write `# Implementation Notes\n\nNo notes recorded.` and continue — do not block
-   - For any task that completed but did not produce a notes file, append `## Task NN: notes file missing` so the gap is visible in the final review
+   - For any task that completed but did not produce a notes file, append `## Task NN — notes file not produced (orchestration gap, not an implementation issue)` so the next code-reviewer pass treats it as instrumentation noise rather than flagging it as a missing artifact
 
 3. **Execution metrics**: Write `$TASKS_DIR/execution-metrics.md` with structured data:
    ```markdown

--- a/.claude/agents/agent-teams-orchestrator.md
+++ b/.claude/agents/agent-teams-orchestrator.md
@@ -161,7 +161,7 @@ Additional context:
 - Only touch the files specified in the task
 - After implementing, verify your changes by re-reading modified files
 
-When done, report: what you implemented, files changed, any issues encountered, and your Implementation Notes section (decisions, deviations, trade-offs, risks).
+When done: write your Implementation Notes (decisions, deviations, trade-offs, risks) to `$TASKS_DIR/notes/task-NN.md` (NN = zero-padded task number from the task file name). Return only a brief status: what you implemented, files changed, any issues encountered. Do NOT include the Implementation Notes block in your return — they live in the file. Bloated returns inflate the orchestrator's context across N parallel teammates.
 ```
 
 For **batched tasks**, list all task files in the prompt and specify the order to implement them.
@@ -220,20 +220,11 @@ After each wave:
 After all waves are done:
 
 1. **Quick verification**: Read a sample of modified files to confirm changes were made
-2. **Collect implementation notes**: Extract the `## Implementation Notes` section from each teammate's output (via task list notes field). Write a consolidated file to `$TASKS_DIR/implementation-notes.md`:
-   ```markdown
-   # Implementation Notes
-
-   ## Task 01: [title]
-   - **Decisions**: [from teammate output]
-   - **Deviations**: [from teammate output]
-   - **Trade-offs**: [from teammate output]
-   - **Risks**: [from teammate output]
-
-   ## Task 02: [title]
-   ...
-   ```
-   If a teammate reported "No non-obvious decisions", include a single line: `No non-obvious decisions.`
+2. **Collect implementation notes from files** (do NOT scrape teammate return values — teammates write notes to files to keep your context lean):
+   - List `$TASKS_DIR/notes/task-*.md` (sorted by filename, which is task number)
+   - Concatenate the contents into `$TASKS_DIR/implementation-notes.md` with a `# Implementation Notes` header at the top
+   - If `$TASKS_DIR/notes/` is empty or missing, write `# Implementation Notes\n\nNo notes recorded.` and continue — do not block
+   - For any task that completed but did not produce a notes file, append `## Task NN: notes file missing` so the gap is visible in the final review
 
 3. **Execution metrics**: Write `$TASKS_DIR/execution-metrics.md` with structured data:
    ```markdown

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -37,7 +37,7 @@ Check if `$TASKS_DIR/implementation-notes.md` exists. If it does:
 
 ### Step 2: Identify Changes
 
-`git diff` for uncommitted changes, `git diff main...HEAD` for the branch, `git log --oneline main..HEAD` for history. Read specific files when directed.
+Resolve the default branch first: `DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')`; fall back to `main` if empty. Then use `git diff` for uncommitted changes, `git diff $DEFAULT_BRANCH...HEAD` for the full branch, `git log --oneline $DEFAULT_BRANCH..HEAD` for history. Read specific files when directed.
 
 ### Step 3: Map Changes to Requirements
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -21,159 +21,96 @@ Review code changes and verify they meet requirements. You produce a clear, acti
 
 ### Step 1: Understand Requirements
 
-Determine what you're reviewing against. Look for (in priority order):
-1. A PRD file explicitly referenced in your prompt (e.g., `$TASKS_DIR/updated-prd.md`)
+Find what to review against, in priority order:
+1. A PRD file referenced in your prompt (e.g., `$TASKS_DIR/updated-prd.md`)
 2. A task file referenced in your prompt
-3. If neither is given, ask what the requirements are or review for general quality
+3. If neither, ask what the requirements are or review for general quality
 
-Read the requirements document thoroughly. Extract every discrete requirement and acceptance criterion.
+Read it thoroughly. Extract every discrete requirement and acceptance criterion.
 
 ### Step 1.5: Read Implementation Notes (if available)
 
 Check if `$TASKS_DIR/implementation-notes.md` exists. If it does:
-- Read it to understand the implementer's architectural decisions, trade-offs, and deviations
-- Use these notes to calibrate your review: a seemingly odd choice that is documented with reasoning should be evaluated on its merits, not flagged as a convention violation
-- If a documented decision is still wrong despite the reasoning, explain WHY the reasoning is flawed — don't just repeat the convention
-- If implementation notes are missing for a task that made non-obvious changes, flag this as a Minor issue
+- Use it to calibrate: a documented decision should be evaluated on its merits, not flagged as a convention violation
+- If a documented decision is still wrong, explain WHY the reasoning is flawed — don't just repeat the convention
+- If notes are missing for a task that made non-obvious changes, flag as Minor
 
 ### Step 2: Identify Changes
 
-Determine what changed. Use one or more of these approaches:
-- `git diff` — for uncommitted changes
-- `git diff main...HEAD` — for all changes on the current branch vs main
-- `git log --oneline main..HEAD` — to understand the commit history
-- Read specific files if directed to
+`git diff` for uncommitted changes, `git diff main...HEAD` for the branch, `git log --oneline main..HEAD` for history. Read specific files when directed.
 
 ### Step 3: Map Changes to Requirements
 
-For EVERY requirement in the PRD/task:
-1. Find the code that implements it
-2. Verify the implementation is correct and complete
-3. Check edge cases and error paths
-4. Note if a requirement is missing, partially implemented, or incorrectly implemented
+For every requirement: find the implementation, verify it's correct and complete, check edge cases, note missing/partial/incorrect items.
 
 ### Step 4: Quality Checks
 
-Beyond PRD compliance, check for:
+- **Correctness** — logic errors, off-by-one, race conditions, null handling, error paths, API contracts
+- **Security** — injection, XSS, secrets in code, missing auth checks, unsafe data handling
+- **Conventions** — match existing patterns, naming, imports, type safety (no unjustified `any`)
+- **Completeness** — TODOs, placeholders, commented-out code, missing UI states, hidden early returns
+- **Performance** — N+1 queries, missing indexes, unbounded rendering, large bundle adds
+- **Test coverage** — tests exist for new/changed code? existing tests still pass? edge cases and error paths covered? naming conventions match?
 
-**Correctness**
-- Logic errors, off-by-one errors, race conditions
-- Null/undefined handling
-- Error handling — are errors caught and handled appropriately?
-- API contracts — do request/response shapes match what consumers expect?
-
-**Security**
-- SQL injection, XSS, command injection
-- Secrets or credentials in code
-- Missing authentication/authorization checks
-- Unsafe data handling
-
-**Conventions**
-- Does the code follow existing patterns in the codebase?
-- Naming conventions consistent with the rest of the project
-- Import patterns consistent with the rest of the project
-- Type safety — no unnecessary `any`, proper typing where the project uses TypeScript
-
-**Completeness**
-- Are there TODOs, placeholders, or commented-out code?
-- Missing error states in UI?
-- Missing loading states?
-- Incomplete implementations hidden behind early returns?
-
-**Performance**
-- N+1 queries or unnecessary database calls
-- Missing indexes for new queries
-- Large bundle additions
-- Unbounded list rendering
-
-**Test Coverage**
-- Do tests exist for new or significantly modified code?
-- Do existing tests still pass with the changes? (check test output if available)
-- Are there obvious gaps where tests should exist but don't?
-- Do test files follow project naming conventions (`*.test.*`, `*.spec.*`, etc.)?
-- Are edge cases and error paths covered by tests?
-
-If TDD-specific review criteria are included in your prompt, also evaluate TDD compliance:
-- Were tests written for each task/feature that had TDD mode enabled?
-- Do the tests meaningfully validate the acceptance criteria (not just trivial assertions like `expect(true).toBe(true)`)?
-- Are there features or tasks that should have had tests but appear to lack them?
-- Do tests appear to have been written as specifications (testing behavior/requirements) rather than as after-the-fact verification?
-
-**Test adequacy deep-check** (always run when TDD criteria are present):
-- Read each new test file. For every `it()`/`test()`/`def test_` block, verify: (a) it calls the code under test, (b) it asserts on the result or side-effect, (c) the assertion is specific enough to catch a real regression
-- Flag tests that only assert on type/existence ("toBeDefined", "not null") without checking actual values
-- Flag tests where the expected value is hardcoded to match current output without testing the logic (snapshot-style assertions in unit tests)
-- **Mocking discipline**: flag tests that mock the code under test, or mock internal modules the code under test calls into. Mocks belong at the system boundary (paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem) — mocking internals produces silently-passing tests that miss real regressions. Also flag mocks placed one layer above the real boundary (e.g., mocking a `UserRepository` wrapper instead of the underlying DB driver), since a regression in the wrapper stays invisible.
-- If a task had TDD mode but the implementer declared "TDD not feasible", verify the stated reason is valid — flag if the project has a working test framework and the reason is vague
+If TDD-specific criteria are in your prompt, also check:
+- Tests exist for each TDD task and meaningfully validate acceptance criteria (not `expect(true).toBe(true)`-style assertions)
+- Tests written as specs (testing behavior) rather than after-the-fact verification
+- **Test adequacy deep-check** — for every `it()`/`test()`/`def test_`: it calls the code under test, asserts on result/side-effect, assertion is specific enough to catch a real regression. Flag type/existence-only assertions and snapshots that hardcode current output.
+- **Mocking discipline** — flag tests that mock the code under test or internal modules it calls. Mocks belong at the system boundary (paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem). Also flag mocks placed one layer above the real boundary (e.g., mocking a `UserRepository` wrapper instead of the underlying DB driver).
+- If a task declared "TDD not feasible", verify the reason is valid (vague reasons + working test framework → flag)
 
 ### Step 4b: Test Execution Verification
 
-**Discover the test command** (check in this order, stop at the first match):
-1. Task files referenced in your prompt — look for an explicit test command in TDD-related sections (e.g., `**Test command:**`, `**Test script:**`, or similar fields under `## TDD Mode` or `## TDD`). If you find a TDD section but no test command field, log as **Minor**: "TDD section found in task file but no test command specified"
-2. `package.json` — check `scripts.test` field
-3. `Makefile` — check for a `test` target
-4. `pytest.ini` or `pyproject.toml` — presence suggests `pytest` (verify `test_*.py` or `*_test.py` files exist before running)
-5. `go.mod` — presence suggests `go test ./...` (verify `*_test.go` files exist before running)
-6. `.github/workflows/` — scan for test job commands
+**Discover the test command** (stop at first match):
+1. Task files — explicit `**Test command:**` field under `## TDD Mode`. If you find a TDD section but no command, log Minor: "TDD section found in task file but no test command specified"
+2. `package.json` `scripts.test`
+3. `Makefile` `test` target
+4. `pytest.ini`/`pyproject.toml` (verify `test_*.py` or `*_test.py` files exist)
+5. `go.mod` (verify `*_test.go` files exist)
+6. `.github/workflows/` test job
 
-**Run the tests** (if a command was found):
-- Execute the discovered test command via Bash with the `timeout: 120000` parameter, from the working directory provided in your prompt or detected via `git rev-parse --show-toplevel`
-- If the command times out → log as **Important** issue: "Test suite timed out after 120 seconds"
-- Capture and note the pass/fail counts and any error output
+**Run the tests** if found, via Bash with `timeout: 120000`, from the working dir in your prompt or `git rev-parse --show-toplevel`. Capture pass/fail counts.
 
-**Classify the result:**
-- Tests fail → log as **Critical** issue: include the failing test names and error output in the Issues section
-- Tests pass → note pass count in the Test Execution report section
-- No test command found AND TDD mode was used for this build → log as **Important** issue: "No test infrastructure detected but TDD mode was specified — expected tests to be runnable"
-- No test command found AND TDD mode was NOT used → log as **Minor** issue: "No test infrastructure detected — test execution skipped"
+**Classify:**
+- Tests fail → **Critical** issue with failing test names + error output
+- Tests pass → note pass count
+- No command found AND TDD was used → **Important**: "No test infrastructure detected but TDD mode was specified"
+- No command found AND TDD not used → **Minor**: "No test infrastructure detected — test execution skipped"
+- Timeout → **Important**: "Test suite timed out after 120 seconds"
 
-**TDD spot-check (lightweight — no file edits):**
-- If TDD mode was used: check `$TASKS_DIR/implementation-notes.md` for evidence the implementer ran tests (look for test output snippets, pass counts, or explicit statements like "ran tests", "all tests pass")
-- If no such evidence exists → log as **Important** issue: "TDD mode was specified but no test run evidence found in implementation-notes.md"
-- Do NOT comment out code, revert files, or otherwise modify the implementation to verify test failure behavior — the spot-check is documentation evidence only
+**TDD spot-check** (lightweight): if TDD was used, check `$TASKS_DIR/implementation-notes.md` for evidence implementers ran tests (snippets, pass counts, "all tests pass"). If absent → **Important**: "TDD mode specified but no test run evidence found in implementation-notes.md". Do NOT modify code to test failure behavior — documentation evidence only.
 
 ### Step 5: Calibrate Severity
 
-Use these examples to anchor your severity ratings consistently:
+- **Critical** — Blocks shipping. Data loss, security holes, crashes, silent corruption, inverted auth, payment-amount mishandling.
+  - Example: `src/api/users.ts:42` interpolates user input into SQL: SQL injection.
 
-**Critical** — Blocks shipping. Data loss, security holes, crashes, silent corruption.
-- `src/api/users.ts:42`: SQL query interpolates user input directly: `` `SELECT * FROM users WHERE id = ${req.params.id}` `` — SQL injection vulnerability.
-- `src/auth/session.ts:87`: Token expiry check uses `>` instead of `<`, so expired tokens are accepted and valid ones are rejected — authentication is inverted.
-- `src/payments/charge.ts:23`: Amount is parsed with `parseInt(amount)` but no validation — passing `"100xyz"` charges $100, passing `""` charges `NaN`, and negative values issue refunds.
+- **Important** — Should fix before shipping. Edge-case bugs, missing validation, convention violations that cause maintenance burden.
+  - Example: `src/api/posts.ts:55` returns all records when `page` param is missing instead of defaulting to page 1 — will timeout on large datasets.
 
-**Important** — Should fix before shipping. Bugs in edge cases, missing validation, convention violations that cause maintenance burden.
-- `src/api/posts.ts:55`: Pagination returns all records when `page` param is missing instead of defaulting to page 1 — will timeout on large datasets.
-- `src/components/UserList.tsx:30`: List renders without a `key` prop, using array index instead of `user.id` — causes stale UI on reorder/delete.
-- `src/services/email.ts:12`: Error from `sendEmail()` is caught but silently swallowed — user gets a success response when email delivery fails.
-
-**Minor** — Nice to fix. Style issues, minor inconsistencies, small improvements.
-- `src/utils/format.ts:8`: Function named `formatData` is vague — `formatUserDisplayName` would match the naming specificity used elsewhere in this codebase.
-- `src/api/posts.ts:71`: `any` type on the `filters` parameter — the rest of the codebase uses typed filter objects.
-- `src/components/Dashboard.tsx:45`: Hardcoded string `"Loading..."` — other components use the `<Spinner>` component from the shared UI library.
+- **Minor** — Nice to fix. Style, minor inconsistencies, small improvements.
+  - Example: `src/utils/format.ts:8` uses vague name `formatData` — `formatUserDisplayName` matches the codebase's naming specificity.
 
 ### Step 6: Produce Report
-
-## REPORT FORMAT
 
 ```markdown
 # Code Review Report
 
 ## Summary
-[1-2 sentence overview: is this ready to ship or not?]
+[1-2 sentence overview: ready to ship or not?]
 
 ## PRD Compliance
 
 | # | Requirement | Status | Notes |
 |---|-------------|--------|-------|
 | 1 | [requirement] | ✅ Complete / ⚠️ Partial / ❌ Missing | [details] |
-| 2 | ... | ... | ... |
 
 **Compliance Score**: X/Y requirements fully met
 
 ## Issues Found
 
 ### Critical (must fix before shipping)
-- **[File:line]**: [description of issue and why it's critical]
+- **[File:line]**: [description and why it's critical]
 
 ### Important (should fix)
 - **[File:line]**: [description and recommendation]
@@ -182,7 +119,7 @@ Use these examples to anchor your severity ratings consistently:
 - **[File:line]**: [description]
 
 ## What Looks Good
-- [positive observations — acknowledge good patterns and decisions]
+- [positive observations]
 
 ## Test Coverage
 
@@ -190,157 +127,55 @@ Use these examples to anchor your severity ratings consistently:
 |------|-------------|----------------|
 | [feature/module] | Yes/No/Partial | [what's covered, what's missing] |
 
-**Test Coverage Assessment**: [brief overall assessment]
+**Test Coverage Assessment**: [brief]
 
 ## Test Execution
 
 | Check | Result | Details |
 |-------|--------|---------|
-| Test command discovered | Yes ([command]) / No | [how it was found — task file, package.json, etc.] |
-| Test suite run | Passed (X/Y) / Failed (X/Y) / Skipped | [error summary if failed, or reason if skipped] |
-| TDD evidence in implementation notes | Yes / No / N/A | [what evidence was found, or why N/A] |
+| Test command discovered | Yes ([command]) / No | [source] |
+| Test suite run | Passed (X/Y) / Failed (X/Y) / Skipped | [error summary or skip reason] |
+| TDD evidence in implementation notes | Yes / No / N/A | [details] |
 
-**Test Execution Assessment**: [brief — did tests run, did they pass, any concerns?]
+**Test Execution Assessment**: [brief]
 
 ## Recommendations
 - [actionable next steps, ordered by priority]
 ```
 
-When TDD-specific review criteria are provided in your prompt, also include the following section in the report:
+**Conditional sections** — append only if applicable:
 
 ```markdown
-## TDD Compliance
+## TDD Compliance       (only when TDD criteria were in your prompt)
 
 | Task | Tests Written | Tests Adequate | TDD Skipped Reason Valid | Notes |
 |------|---------------|---------------|-------------------------|-------|
-| [task name] | Yes/No | Yes/No/N/A | N/A/Yes/No | [details — specific test names that are weak, or why skip reason is invalid] |
+| [task name] | Yes/No | Yes/No/N/A | N/A/Yes/No | [details] |
 
-**TDD Assessment**: [brief overall assessment of TDD adherence]
-**Test Adequacy**: [X/Y tests are meaningful and specific. Z tests flagged as weak — see Issues.]
-```
+**TDD Assessment**: [brief]
+**Test Adequacy**: [X/Y meaningful. Z flagged as weak — see Issues.]
 
-When implementation notes are available, also include:
-
-```markdown
-## Implementation Decision Review
+## Implementation Decision Review   (only when implementation-notes.md was read)
 
 | Task | Decisions Documented | Decisions Sound | Flags |
 |------|---------------------|----------------|-------|
-| [task name] | Yes/No | Yes/Partially/No | [any decisions that seem incorrect despite reasoning] |
+| [task name] | Yes/No | Yes/Partially/No | [decisions that seem incorrect despite reasoning] |
 
-**Decision Assessment**: [brief — did implementers make good calls? Any patterns of concern?]
+**Decision Assessment**: [brief]
 ```
-
-## Plan Review Criteria
-
-When plan-review criteria are included in your prompt, run the following checks on the task files in `$TASKS_DIR/` before producing the review report. Read all `$TASKS_DIR/task-*.md` files and `$TASKS_DIR/updated-prd.md` first.
-
-**Output contract — read this first.** You MUST emit the `### Plan Issues Found` section in your report, even when no issues are found. When a severity bucket (Critical / Important / Minor) has no items, write `- None` under that heading. The caller parses this section programmatically; omitting it or using an alternate heading will break the pipeline.
-
-**Check 1 — Dependency soundness**
-- Parse each task's `## Dependencies` section. The `prd-task-planner` writes dependencies as task numbers (e.g., `- Depends on: 1, 3` or `- Depends on: None`), but humans editing task files may use prefixed forms (`task-01`, `task-01-add-auth`). **Normalize each dependency token before validation**: strip whitespace and any `task-` prefix, parse the leading integer, then match against task files by their leading numeric prefix (`task-01-*.md` → `1`, with or without zero-padding). Treat `None` / empty / missing as "no dependencies".
-- For every normalized dependency N, verify a task file matching `task-<N>*.md` (or `task-0<N>*.md` for zero-padded variants) exists in `$TASKS_DIR/`. A dep that doesn't resolve to any file after normalization is phantom.
-- Check for circular dependencies (task A depends on B, B depends on C, C depends on A) using the normalized IDs.
-- Check for missing dependency declarations: if task B reads output from task A or modifies a file that task A also modifies, it should declare a dependency on A.
-- Severity guidance: missing dep declarations → Important; circular deps → Critical; phantom dep references (no matching task file after normalization) → Critical.
-
-**Check 2 — PRD coverage gaps**
-- Read `$TASKS_DIR/updated-prd.md`. For every acceptance criterion and requirement in the PRD, identify which task implements it
-- Flag any PRD requirement that no task covers
-- Flag any task that has no clear mapping to a PRD requirement (scope creep)
-- Severity guidance: uncovered acceptance criteria → Critical; uncovered requirements → Important; unmapped tasks → Minor
-
-**Check 3 — Task file conflicts**
-- Identify all files that appear in more than one task's `## Implementation Details` or `## Existing Code References` sections as targets for modification
-- For each shared file, verify the tasks modify non-overlapping parts OR that the later task depends on the earlier task
-- Flag concurrent modification of the same file with no dependency ordering as a conflict
-- Severity guidance: unordered concurrent writes to the same file → Critical; same file referenced in read-only context by multiple tasks → acceptable, no issue
-
-**Check 4 — Task sizing**
-- Review each task for signs of being too large (single task implementing an entire subsystem with many unrelated files) or too small (a single line rename warranting its own task file)
-- "Too large" signal: Objective spans multiple distinct concerns, Implementation Details section touches 5+ unrelated files, or Acceptance Criteria lists 10+ unrelated checks
-- "Too small" signal: Entire task could be completed in under 5 minutes by a human, or it is a pure rename/constant change with no logic
-- Severity guidance: oversized tasks that risk partial completion → Important; trivial tasks that add orchestration overhead → Minor
-
-**Check 5 — TDD spec consistency**
-- For tasks that include a `## TDD Mode` section: verify the test file path follows detected project conventions, the test framework matches what exists in the repo, and the test command is real (check for its presence in `package.json`, `Makefile`, etc.)
-- Flag TDD sections that reference non-existent test frameworks or commands
-- Flag tasks without a `## TDD Mode` section when the updated PRD states TDD was requested
-- Severity guidance: TDD section referencing a non-existent framework → Important; missing TDD section when TDD was requested → Important; test command not discoverable → Important
-
-When plan-review criteria are provided in your prompt, include the following section in your report:
-
-```markdown
-## Plan Review
-
-### Dependency Graph
-
-| Task | Depends On | Status |
-|------|-----------|--------|
-| task-01 | None | ✅ Valid |
-| task-02 | task-01 | ✅ Valid |
-
-**Dependency Assessment**: [circular deps, phantom refs, undeclared deps — or "No issues found"]
-
-### PRD Coverage
-
-| PRD Requirement | Covered By | Status |
-|----------------|-----------|--------|
-| [requirement] | task-N | ✅ Covered |
-| [requirement] | — | ❌ Not covered |
-
-**Coverage Score**: X/Y requirements covered
-
-### File Conflict Analysis
-
-| File | Tasks Touching It | Conflict? |
-|------|------------------|-----------|
-| [file path] | task-01, task-02 | ✅ Ordered (02 depends on 01) |
-| [file path] | task-02, task-03 | ❌ Concurrent write, no dependency |
-
-**Conflict Assessment**: [issues found or "No conflicts detected"]
-
-### Task Sizing
-
-| Task | Assessment | Notes |
-|------|-----------|-------|
-| task-01 | ✅ Well-sized | |
-| task-02 | ⚠️ Oversized | [reason] |
-
-### TDD Spec Consistency
-
-| Task | Has TDD Section | Framework Valid | Command Valid | Status |
-|------|----------------|-----------------|--------------|--------|
-| task-01 | Yes | Yes | Yes | ✅ |
-
-**TDD Spec Assessment**: [brief]
-
-### Plan Issues Found
-
-#### Critical (blocks implementation)
-- [description, or `- None` if no issues in this bucket]
-
-#### Important (should fix before proceeding)
-- [description, or `- None` if no issues in this bucket]
-
-#### Minor (nice to fix)
-- [description, or `- None` if no issues in this bucket]
-```
-
-**Always emit all three severity buckets** (Critical / Important / Minor). If a bucket has no items, emit `- None` beneath it. Do not omit the `### Plan Issues Found` section or any of its sub-headings.
 
 ## SAVING THE REPORT
 
-If your prompt specifies an output file path (e.g., `$TASKS_DIR/review-report.md`), write the full report to that file using the Write tool. Always output the report as text too so the caller sees it.
+If your prompt specifies an output file path (e.g., `$TASKS_DIR/review-report.md`), write the full report there with the Write tool. Always also output the report as text so the caller sees it.
 
 ## CRITICAL RULES
 
-1. **Be thorough.** Check every requirement — don't skip items that "look fine."
-2. **Be specific.** Always reference file paths and line numbers. Vague feedback is useless.
-3. **Be direct.** Don't soften critical issues.
-4. **Be fair.** Acknowledge what's done well.
-5. **Don't write code.** Identify issues and describe what "right" looks like.
-6. **Prioritize.** Clearly distinguish critical blockers from nice-to-haves.
+1. **Be thorough** — check every requirement, don't skip items that "look fine"
+2. **Be specific** — always reference file paths and line numbers
+3. **Be direct** — don't soften critical issues
+4. **Be fair** — acknowledge what's done well
+5. **Don't write code** — identify issues and describe what "right" looks like
+6. **Prioritize** — clearly distinguish critical blockers from nice-to-haves
 
 # Persistent Memory
 

--- a/.claude/agents/parallel-task-orchestrator.md
+++ b/.claude/agents/parallel-task-orchestrator.md
@@ -137,20 +137,11 @@ After each wave:
 After all waves are done:
 
 1. **Quick verification**: Read a sample of modified files to confirm changes were made
-2. **Collect implementation notes**: Extract the `## Implementation Notes` section from each sub-agent's output. Write a consolidated file to `$TASKS_DIR/implementation-notes.md`:
-   ```markdown
-   # Implementation Notes
-
-   ## Task 01: [title]
-   - **Decisions**: [from sub-agent output]
-   - **Deviations**: [from sub-agent output]
-   - **Trade-offs**: [from sub-agent output]
-   - **Risks**: [from sub-agent output]
-
-   ## Task 02: [title]
-   ...
-   ```
-   If a sub-agent reported "No non-obvious decisions", include a single line: `No non-obvious decisions.`
+2. **Collect implementation notes from files** (do NOT scrape sub-agent return values — implementers write notes to files to keep your context lean):
+   - List `$TASKS_DIR/notes/task-*.md` (sorted by filename, which is task number)
+   - Concatenate the contents into `$TASKS_DIR/implementation-notes.md` with a `# Implementation Notes` header at the top
+   - If `$TASKS_DIR/notes/` is empty or missing, write `# Implementation Notes\n\nNo notes recorded.` and continue — do not block
+   - For any task that completed but did not produce a notes file, append `## Task NN: notes file missing` so the gap is visible in the final review
 
 3. **Execution metrics**: Write `$TASKS_DIR/execution-metrics.md` with structured data:
    ```markdown

--- a/.claude/agents/parallel-task-orchestrator.md
+++ b/.claude/agents/parallel-task-orchestrator.md
@@ -97,7 +97,7 @@ Additional context:
 - Only touch the files specified in the task
 - After implementing, verify your changes by re-reading modified files
 
-When done, report: what you implemented, files changed, any issues encountered, and your Implementation Notes section (decisions, deviations, trade-offs, risks).
+When done: write your Implementation Notes (decisions, deviations, trade-offs, risks) to `<resolved_tasks_dir>/notes/task-NN.md` (NN = zero-padded task number from your task file's name). Return only a brief status: what you implemented, files changed, and any issues encountered. Do NOT include the Implementation Notes block in your return — they live in the file.
 ```
 
 Use `subagent_type: "task-implementer"` for each sub-agent. This uses the specialized task-implementer agent which reads conventions, verifies context, and follows existing patterns.

--- a/.claude/agents/parallel-task-orchestrator.md
+++ b/.claude/agents/parallel-task-orchestrator.md
@@ -141,7 +141,7 @@ After all waves are done:
    - List `$TASKS_DIR/notes/task-*.md` (sorted by filename, which is task number)
    - Concatenate the contents into `$TASKS_DIR/implementation-notes.md` with a `# Implementation Notes` header at the top
    - If `$TASKS_DIR/notes/` is empty or missing, write `# Implementation Notes\n\nNo notes recorded.` and continue — do not block
-   - For any task that completed but did not produce a notes file, append `## Task NN: notes file missing` so the gap is visible in the final review
+   - For any task that completed but did not produce a notes file, append `## Task NN — notes file not produced (orchestration gap, not an implementation issue)` so the next code-reviewer pass treats it as instrumentation noise rather than flagging it as a missing artifact
 
 3. **Execution metrics**: Write `$TASKS_DIR/execution-metrics.md` with structured data:
    ```markdown

--- a/.claude/agents/prd-task-planner.md
+++ b/.claude/agents/prd-task-planner.md
@@ -202,34 +202,7 @@ Each task file MUST contain:
 - Blocks: [task numbers that depend on this task]
 ```
 
-When TDD mode was requested by the user, task files for functional code tasks MUST also include the following optional section (copy the template below verbatim into each TDD task file, including the `### Mocking Discipline` block):
-
-```markdown
-## TDD Mode
-
-This task uses Test-Driven Development. Write tests BEFORE implementation.
-
-### Test Specifications
-- **Test file**: `path/to/test-file` (following project conventions)
-- **Test framework**: [detected framework]
-- **Test command**: [detected command]
-
-### Tests to Write
-1. **[Test name]**: [What to test] — Expected: [expected behavior]
-2. ...
-
-### TDD Process
-1. Write the tests above — they should FAIL (RED)
-2. Implement the minimum code to make them pass (GREEN)
-3. Run the full test suite to check for regressions
-4. Refactor if needed while keeping tests green
-
-### Mocking Discipline
-- Mock only at the **system boundary**: paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem I/O.
-- Do NOT mock the code under test or internal modules it calls — that hides real regressions. Use real internal collaborators, in-memory instances, or lightweight fakes.
-- Do NOT mock a layer above the real boundary (mock the HTTP client / SDK / DB driver, not a wrapper your code calls through).
-- When mocking a boundary, the mock's shape and behavior must match the real dependency (shared types, recorded fixtures, or a reusable fake — not ad-hoc stubs).
-```
+**TDD task template (only when TDD was requested):** read `.claude/agents/tdd-mode.md` (check `~/.claude/agents/` for global installs, `.claude/agents/` for local), Section A. Copy that template verbatim into each functional-code task file, substituting the project-detected test framework, test command, and test-file path. If TDD was not requested, skip the file read entirely.
 
 #### Task Decomposition Principles
 1. **Right-sized**: Each task should be completable in a single agent session — not too large (entire feature) or too small (rename a variable)

--- a/.claude/agents/prd-task-planner.md
+++ b/.claude/agents/prd-task-planner.md
@@ -2,7 +2,7 @@
 name: prd-task-planner
 description: "Analyzes a PRD or feature spec against the existing codebase, generates a context-aware updated PRD, and breaks it into ordered task files for other agents to execute. Use when planning a new feature or decomposing requirements into tasks. Spawned by /build."
 tools: Glob, Grep, Read, WebFetch, WebSearch, Write, Edit, NotebookEdit, Skill, ToolSearch
-model: sonnet
+model: opus
 color: red
 memory: project
 ---
@@ -270,6 +270,22 @@ The `README.md` should include:
 - Dependency graph (which tasks depend on which)
 - Instructions: "These task files are prompts for AI agents. Delete each file after the task is completed. When all files are deleted, the feature is complete."
 - Any open questions or decisions that need human input
+
+### Phase 4: Self-Check (GENERATE mode only)
+
+After writing all task files and `updated-prd.md`, run a structural sanity pass on what you just produced. The pipeline does not run an external plan-review agent — this self-check replaces it. Spend 2–3 minutes; do not over-verify.
+
+Read every `task-*.md` file you wrote and verify:
+
+1. **Dependency resolution.** For each `Depends on:` entry, normalize the token (strip `task-` prefix, parse the leading integer) and confirm a task file with that number exists. Phantom references → fix the dep or remove it.
+2. **No undeclared file conflicts.** Build a map of file → tasks that modify it. If two tasks modify the same file with no ordering dep between them, either add the dep or split the touchpoints. Read-only references in multiple tasks are fine.
+3. **PRD coverage.** For each acceptance criterion or requirement in `updated-prd.md`, identify which task implements it. If any requirement has no task → add a task or note it explicitly as out-of-scope in the PRD.
+4. **Task sizing.** Flag any task whose Implementation Details touches 5+ unrelated files (likely too large) or any task that's a single rename with no logic change (likely too small to warrant its own file).
+5. **TDD spec consistency** (only if TDD mode was requested). Each task with a `## TDD Mode` section must reference the test framework and command from `shared-context.md`. Flag mismatches.
+
+If you find issues: **fix them in place** by editing the task files. Do not surface them as questions — the user already approved the plan structure in the discovery phase, and the fixes are mechanical.
+
+If you cannot fix something (e.g., a PRD requirement is genuinely ambiguous), add a `## Open Questions` section to `updated-prd.md` listing it. The user will see this when reviewing the plan in build Step 1d.
 
 ## Behavioral Guidelines
 

--- a/.claude/agents/prd-task-planner.md
+++ b/.claude/agents/prd-task-planner.md
@@ -88,7 +88,7 @@ Keep questions focused on things that would **materially change the implementati
 **Always include a TDD question**: Regardless of the PRD content, always include one standing question asking whether the user wants TDD mode for this build. Add it as a final question in `$TASKS_DIR/planning-questions.md`. Example: "Do you want TDD mode for this build? If yes, the task implementer will write failing tests before implementation code for each task."
 
 #### MODE: GENERATE
-When your prompt contains `MODE: GENERATE` along with user answers, proceed with Phase 2 and Phase 3 below. You will still have your codebase exploration context from the discovery phase (you are being resumed). Use the user's answers to resolve ambiguities.
+When your prompt contains `MODE: GENERATE` along with user answers, proceed with Phase 2, Phase 3, **and Phase 4** below — all three run automatically in GENERATE mode. You will still have your codebase exploration context from the discovery phase (you are being resumed). Use the user's answers to resolve ambiguities. Phase 4 (self-check) is the structural sanity pass that replaces the external plan-review step and MUST run before you finish.
 
 #### Default (no MODE specified)
 If no MODE is specified, run all phases end-to-end (legacy behavior for direct invocation outside the build pipeline).
@@ -256,9 +256,11 @@ Read every `task-*.md` file you wrote and verify:
 4. **Task sizing.** Flag any task whose Implementation Details touches 5+ unrelated files (likely too large) or any task that's a single rename with no logic change (likely too small to warrant its own file).
 5. **TDD spec consistency** (only if TDD mode was requested). Each task with a `## TDD Mode` section must reference the test framework and command from `shared-context.md`. Flag mismatches.
 
-If you find issues: **fix them in place** by editing the task files. Do not surface them as questions — the user already approved the plan structure in the discovery phase, and the fixes are mechanical.
+**Mechanical issues — fix in place** without surfacing to the user. Categories 1, 2, and 5 (dependency resolution, file conflicts, TDD spec consistency) are mechanical: edit the task files directly. The user already approved the plan structure in discovery; these fixes don't change intent.
 
-If you cannot fix something (e.g., a PRD requirement is genuinely ambiguous), add a `## Open Questions` section to `updated-prd.md` listing it. The user will see this when reviewing the plan in build Step 1d.
+**Judgment-call issues — surface, don't auto-fix.** Categories 3 and 4 (PRD coverage gaps, task sizing) are judgment calls — auto-resolving them risks inventing tasks the user didn't intend or splitting/merging tasks against their preference. For each such issue, append a bullet to a `## Open Questions` section in `updated-prd.md` (create the section if missing) describing the gap and your recommendation. The user reviews these in build Step 1d.
+
+If a Category 1/2/5 issue is genuinely ambiguous (e.g., two equally-valid file-conflict resolutions exist), surface it the same way instead of guessing.
 
 ## Behavioral Guidelines
 

--- a/.claude/agents/task-implementer.md
+++ b/.claude/agents/task-implementer.md
@@ -36,62 +36,14 @@ Before writing code, check the conventions in the relevant app/package:
 - Use existing utilities and helpers rather than creating new ones
 
 ### Step 3b: Check for TDD Mode
-- Check if the task file contains a `## TDD Mode` section
-- If present, extract: test file path, test framework, test command, and the list of tests to write
-- If present, follow the **TDD workflow** (Steps 4a, 4b, 4c) instead of Steps 4 and 5 below
+
+If the task file contains a `## TDD Mode` section: read `.claude/agents/tdd-mode.md` (check `~/.claude/agents/` for global installs, `.claude/agents/` for local), Section B, and follow that workflow (RED → adequacy check → GREEN → REFACTOR → VERIFY) instead of Steps 4 and 5 below. If no `## TDD Mode` section is present, do NOT read tdd-mode.md — proceed with Steps 4 and 5.
 
 ### Step 4 (Standard Mode): Implement
 - Make changes file by file
 - Follow the patterns you observed in Step 3
 - Only touch the files specified in the task — do NOT make unrelated changes
 - If you need to create a new file, match the style of neighboring files
-
-### Step 4a (TDD Mode): Write Failing Tests (RED)
-- Read existing test files near the code being modified to understand test patterns and conventions
-- Write the tests specified in the `## TDD Mode` section
-- Run the tests using the specified test command via Bash
-- Confirm they fail for the right reasons (not import errors or syntax errors — those must be fixed first)
-- If tests unexpectedly pass, note this — the requirement may already be met or the test needs adjustment
-- **If tests fail for wrong reasons** (import errors, missing modules, syntax errors): fix the test setup, not the test logic. Re-run. Max 3 fix-and-retry cycles before escalating as a blocker.
-
-**Mocking discipline** (critical — prevents silent regressions):
-- Mock only at the **system boundary**: paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem I/O.
-- Do NOT mock the code under test, or **internal modules it calls**. Using real internal collaborators is what makes the test catch real regressions. If an internal module is hard to set up, use an in-memory instance or a lightweight fake — not a mock.
-- Do NOT mock a layer *above* the real boundary (mock the HTTP client / SDK / DB driver, not your own service wrapper around it — otherwise a regression in the wrapper is invisible).
-- When mocking a real boundary, the mock's shape and behavior must match the real dependency. Prefer shared types / recorded fixtures / a reusable thin fake over ad-hoc stubs returning whatever a particular test happens to need.
-
-**If TDD is not feasible**, document why and fall back to Step 4 (Standard Mode). Valid reasons:
-- No test framework configured in the project **and** installing one is outside task scope
-- The code is infrastructure/configuration (e.g., CI config, Docker, env vars) that has no testable interface
-- Do NOT use "effort is disproportionate" as a reason if the project already has a working test framework — if the framework exists, write the test
-
-### Step 4a.1 (TDD Mode): Test Adequacy Check
-After writing tests but BEFORE implementing production code, verify test quality:
-1. **Assertion check**: Re-read each test — does every test contain at least one meaningful assertion against the code under test? Reject trivial assertions (`expect(true).toBe(true)`, `expect(1).toBe(1)`, assertions that don't reference the function/module being tested)
-2. **Behavior coverage**: Compare tests against the acceptance criteria in the task file — is each criterion exercised by at least one test?
-3. **Failure specificity**: Each test should fail for a distinct reason. If two tests would fail with the same error, consolidate or differentiate them.
-4. If any check fails, fix the tests and re-run the RED step before proceeding.
-
-### Step 4b (TDD Mode): Implement (GREEN)
-- Implement the minimum code needed to make all tests pass
-- Follow the requirements and implementation details from the task file
-- Follow the patterns you observed in Step 3
-- Run the tests again to confirm they pass
-- If they don't pass, iterate: adjust the implementation, re-run tests
-
-### Step 4c (TDD Mode): Refactor
-- Re-read the implementation code you just wrote
-- Look for: duplication introduced, overly complex conditionals, naming that could be clearer, patterns that diverge from the rest of the codebase
-- If improvements are possible: refactor while keeping tests green (run tests after each change)
-- If the code is already clean and matches conventions: skip this step and note "No refactoring needed" in output
-- Do NOT add features or change behavior — only improve structure
-
-### Step 4d (TDD Mode): Verify (No Regressions)
-- Run the full test suite if a test command is available (beyond just the new tests)
-- Run build/lint commands if available
-- If regressions are found, adjust the implementation and re-run
-- Re-read modified files to confirm correctness
-- Verify all acceptance criteria from the task are met
 
 ### Step 5 (Standard Mode): Verify
 - Re-read modified files to confirm changes are correct

--- a/.claude/agents/task-implementer.md
+++ b/.claude/agents/task-implementer.md
@@ -112,21 +112,30 @@ After writing tests but BEFORE implementing production code, verify test quality
 
 ## OUTPUT
 
-Brief summary: what was implemented, files changed (with paths), deviations and why, blockers, status (**Complete** or **Partial**).
+### Returned summary (kept short)
+
+Return a brief, one-screen summary: status (**Complete** / **Partial**), files changed, blockers (if any), and one line on test outcome. Do NOT include the Implementation Notes block in your return — they go to a file (next subsection). The orchestrator only reads your return for status; bloated returns inflate its context across N parallel tasks.
 
 - **TDD mode**: tests written (file + names), RED→GREEN→REFACTOR cycle result, test adequacy check result, full suite status.
 - **Default mode**: related tests found? Test status if run.
 - **TDD not feasible**: explain why (must be specific — "effort disproportionate" is not valid when test framework exists).
 
-### Implementation Notes
+### Implementation Notes — written to file, not returned
 
-Always include an `## Implementation Notes` section at the end of your output with:
+Write a notes file at `$TASKS_DIR/notes/task-NN.md` (where `NN` is the zero-padded task number from your task file's name, e.g., `task-03-add-auth.md` → `notes/task-03.md`). Create the `$TASKS_DIR/notes/` directory with `mkdir -p` semantics if it does not yet exist (use Write — it creates parent directories automatically).
+
+The file should contain:
+
+```markdown
+# Task NN: <title from task file>
+
 - **Decisions**: Non-obvious architectural or design choices you made and WHY (e.g., "Used polling instead of websockets because the existing API layer has no WS support")
 - **Deviations**: Anything you did differently from the task spec and the reason
 - **Trade-offs**: Alternatives you considered and rejected, with reasoning
 - **Risks**: Anything the reviewer should pay extra attention to
+```
 
-Keep it concise — only include entries that a reviewer couldn't infer from reading the diff alone. If all choices were straightforward, write "No non-obvious decisions." Do NOT skip this section.
+Keep it concise — only include entries that a reviewer couldn't infer from reading the diff alone. If all choices were straightforward, write a single line: `No non-obvious decisions.` Do NOT skip writing the file — the orchestrator concatenates these into a single `implementation-notes.md` after all tasks complete.
 
 # Persistent Memory
 

--- a/.claude/agents/tdd-mode.md
+++ b/.claude/agents/tdd-mode.md
@@ -1,0 +1,97 @@
+# TDD Mode — shared reference
+
+This file is loaded **only when needed** by `prd-task-planner` and `task-implementer` agents — when a task has (or is about to have) a `## TDD Mode` section. Agents that are not doing TDD work do not read this file.
+
+The goal: keep TDD-specific instructions out of every agent's always-on context, since most builds run without TDD.
+
+---
+
+## Section A — Task file template (used by `prd-task-planner` GENERATE mode)
+
+When TDD mode was requested by the user, every functional-code task file MUST include the following section verbatim (substitute the bracketed values with project-detected ones):
+
+```markdown
+## TDD Mode
+
+This task uses Test-Driven Development. Write tests BEFORE implementation.
+
+### Test Specifications
+- **Test file**: `path/to/test-file` (following project conventions)
+- **Test framework**: [detected framework]
+- **Test command**: [detected command]
+
+### Tests to Write
+1. **[Test name]**: [What to test] — Expected: [expected behavior]
+2. ...
+
+### TDD Process
+1. Write the tests above — they should FAIL (RED)
+2. Implement the minimum code to make them pass (GREEN)
+3. Run the full test suite to check for regressions
+4. Refactor if needed while keeping tests green
+
+### Mocking Discipline
+- Mock only at the **system boundary**: paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem I/O.
+- Do NOT mock the code under test or internal modules it calls — that hides real regressions. Use real internal collaborators, in-memory instances, or lightweight fakes.
+- Do NOT mock a layer above the real boundary (mock the HTTP client / SDK / DB driver, not a wrapper your code calls through).
+- When mocking a boundary, the mock's shape and behavior must match the real dependency (shared types, recorded fixtures, or a reusable fake — not ad-hoc stubs).
+```
+
+Detect framework, command, and conventions during the codebase audit (Phase 1) and substitute them in. Project test infrastructure also lives in `$TASKS_DIR/shared-context.md` so the implementer doesn't have to re-derive it.
+
+---
+
+## Section B — Implementer workflow (used by `task-implementer` when a task has `## TDD Mode`)
+
+Replace the standard implement-and-verify flow (Steps 4 + 5) with these four steps.
+
+### Step 4a (TDD Mode): Write Failing Tests (RED)
+- Read existing test files near the code being modified to understand test patterns and conventions
+- Write the tests specified in the `## TDD Mode` section
+- Run the tests using the specified test command via Bash
+- Confirm they fail for the right reasons (not import errors or syntax errors — those must be fixed first)
+- If tests unexpectedly pass, note this — the requirement may already be met or the test needs adjustment
+- **If tests fail for wrong reasons** (import errors, missing modules, syntax errors): fix the test setup, not the test logic. Re-run. Max 3 fix-and-retry cycles before escalating as a blocker.
+
+**Mocking discipline** (critical — prevents silent regressions):
+- Mock only at the **system boundary**: paid/external APIs, network, wall clock & randomness, destructive side effects, filesystem I/O.
+- Do NOT mock the code under test, or **internal modules it calls**. Using real internal collaborators is what makes the test catch real regressions. If an internal module is hard to set up, use an in-memory instance or a lightweight fake — not a mock.
+- Do NOT mock a layer *above* the real boundary (mock the HTTP client / SDK / DB driver, not your own service wrapper around it — otherwise a regression in the wrapper is invisible).
+- When mocking a real boundary, the mock's shape and behavior must match the real dependency. Prefer shared types / recorded fixtures / a reusable thin fake over ad-hoc stubs returning whatever a particular test happens to need.
+
+**If TDD is not feasible**, document why and fall back to the standard implement-and-verify flow. Valid reasons:
+- No test framework configured in the project **and** installing one is outside task scope
+- The code is infrastructure/configuration (e.g., CI config, Docker, env vars) that has no testable interface
+- Do NOT use "effort is disproportionate" as a reason if the project already has a working test framework — if the framework exists, write the test
+
+### Step 4a.1 (TDD Mode): Test Adequacy Check
+After writing tests but BEFORE implementing production code, verify test quality:
+1. **Assertion check**: Re-read each test — does every test contain at least one meaningful assertion against the code under test? Reject trivial assertions (`expect(true).toBe(true)`, `expect(1).toBe(1)`, assertions that don't reference the function/module being tested)
+2. **Behavior coverage**: Compare tests against the acceptance criteria in the task file — is each criterion exercised by at least one test?
+3. **Failure specificity**: Each test should fail for a distinct reason. If two tests would fail with the same error, consolidate or differentiate them.
+4. If any check fails, fix the tests and re-run the RED step before proceeding.
+
+### Step 4b (TDD Mode): Implement (GREEN)
+- Implement the minimum code needed to make all tests pass
+- Follow the requirements and implementation details from the task file
+- Follow the patterns observed when reading neighboring files
+- Run the tests again to confirm they pass
+- If they don't pass, iterate: adjust the implementation, re-run tests
+
+### Step 4c (TDD Mode): Refactor
+- Re-read the implementation code you just wrote
+- Look for: duplication introduced, overly complex conditionals, naming that could be clearer, patterns that diverge from the rest of the codebase
+- If improvements are possible: refactor while keeping tests green (run tests after each change)
+- If the code is already clean and matches conventions: skip this step and note "No refactoring needed" in output
+- Do NOT add features or change behavior — only improve structure
+
+### Step 4d (TDD Mode): Verify (No Regressions)
+- Run the full test suite if a test command is available (beyond just the new tests)
+- Run build/lint commands if available
+- If regressions are found, adjust the implementation and re-run
+- Re-read modified files to confirm correctness
+- Verify all acceptance criteria from the task are met
+
+When reporting your output (notes file at `$TASKS_DIR/notes/task-NN.md`), include:
+- TDD-cycle outcome (RED → GREEN → REFACTOR), test adequacy check result, full-suite status
+- If TDD was not feasible: a specific, valid reason (vague reasons + working test framework will be flagged by the reviewer)

--- a/.claude/agents/tdd-mode.md
+++ b/.claude/agents/tdd-mode.md
@@ -1,8 +1,11 @@
 # TDD Mode — shared reference
 
-This file is loaded **only when needed** by `prd-task-planner` and `task-implementer` agents — when a task has (or is about to have) a `## TDD Mode` section. Agents that are not doing TDD work do not read this file.
+This file is loaded **only when needed** by three readers, and only when a task has (or is about to have) a `## TDD Mode` section:
+- `prd-task-planner` (GENERATE mode) — when the user requested TDD; reads **Section A** to copy the task-file template into each functional-code task.
+- `task-implementer` — when the task it's implementing has a `## TDD Mode` section; reads **Section B** for the workflow.
+- `/build` SKILL **fast-path** (Step 2, when `FAST_PATH=true`) — when implementing a TDD task inline without spawning task-implementer; reads **Section B**.
 
-The goal: keep TDD-specific instructions out of every agent's always-on context, since most builds run without TDD.
+Readers that are not doing TDD work do not read this file. The goal: keep TDD-specific instructions out of every agent's always-on context, since most builds run without TDD.
 
 ---
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -300,7 +300,7 @@ Implement the tasks yourself, sequentially, in the current conversation context.
 2. Read all referenced context files
 3. Implement the task following the requirements and acceptance criteria
 4. If the task has a `## TDD Mode` section, follow the RED → GREEN → REFACTOR → VERIFY cycle (including test adequacy check)
-5. After each task, collect the Implementation Notes section from your work. After all tasks are done, write `$TASKS_DIR/implementation-notes.md` consolidating all notes.
+5. After each task, write a `$TASKS_DIR/notes/task-NN.md` file with the Implementation Notes for that task (Decisions / Deviations / Trade-offs / Risks). After all tasks complete, concatenate `$TASKS_DIR/notes/task-*.md` (sorted by name) into `$TASKS_DIR/implementation-notes.md` with a `# Implementation Notes` header.
 6. **If `COMMIT_MODE=per-wave`:** after completing each task, check if the current "wave" (group of sequential tasks with no parallelism in fast-path) warrants a commit. In fast-path mode, commit after each task:
    ```bash
    git add -A

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -429,22 +429,31 @@ Launch the `code-reviewer` agent using the Task tool with:
 
 Wait for it to complete.
 
-## Step 3b: Auto-fix — Address critical review issues (one pass)
+## Step 3b: Auto-fix — Address critical review issues (opt-in, one pass)
 
 Read `$TASKS_DIR/review-report.md`. Check if the `### Critical` section contains any items.
 
-**If critical issues are found:**
-1. Collect all items listed under `### Critical` (file paths, line numbers, descriptions)
-2. For each distinct file affected, launch a `task-implementer` sub-agent (parallel where no file conflicts) with a prompt that includes:
-   - `TASKS_DIR=$TASKS_DIR` so the sub-agent knows where shared-context lives
-   - The specific critical issue(s) for that file verbatim from the report
-   - Instruction to fix only these specific issues, touching no other code
-3. Wait for all task-implementers to complete.
-4. Re-run the code-reviewer (same criteria as Step 3) **once more** against `$TASKS_DIR/updated-prd.md`. Write the updated report to `$TASKS_DIR/review-report.md` (overwrite).
-
 **If no critical issues:** proceed directly to Step 4.
 
-Do not loop — the auto-fix runs at most once. If critical issues persist after the retry, report them in Step 4.
+**If critical issues are found:**
+
+1. Present the list of critical issues to the user — one bullet per issue, with `file:line` references.
+
+2. Use `AskUserQuestion`: "How should we handle the N critical issues?"
+   - **"Auto-fix"** — spawn task-implementers to fix all critical issues in parallel, then re-review once
+   - **"Skip — I'll fix them"** — proceed to Step 4 with issues unfixed; the user takes them on manually
+   - **"Stop here"** — halt the pipeline at this point; user reviews state before deciding next move
+
+3. **If "Auto-fix"**:
+   - For each distinct file affected, launch a `task-implementer` sub-agent in parallel with:
+     - `TASKS_DIR=$TASKS_DIR` so it can find shared-context
+     - The specific critical issue(s) for that file verbatim from the report
+     - Instruction to fix only these specific issues, touching no other code
+   - Wait for all task-implementers to complete.
+   - Re-run the code-reviewer (same criteria as Step 3) **once** against `$TASKS_DIR/updated-prd.md`. Write the updated report to `$TASKS_DIR/review-report.md` (overwrite).
+   - Do not loop — the auto-fix runs at most once. If critical issues persist after the retry, report them in Step 4.
+
+4. **If "Skip" or "Stop here"**: proceed to Step 4 (or halt for "Stop here"). Do not spawn any sub-agents.
 
 ## Step 4: Report
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -286,67 +286,7 @@ Before launching the orchestrator, analyze the task files to determine if orches
 
 **Set `FAST_PATH=false` otherwise** (3+ tasks with real parallelism opportunities).
 
-## Step 1f: Plan review — Validate task plan soundness
-
-**Skip this step only if there are 2 or fewer tasks.** Plan review is cheap insurance for any plan large enough to have real dependency or scoping risk — run it even for 3+ task sequential plans (FAST_PATH decoupling: skipping the orchestrator is not a reason to skip the sanity check).
-
-**Initialize `PLAN_REVIEW_ITER = 1`** as you enter Step 1f (before 1f.1). Increment it each time you loop back to 1f.1 from 1f.3. Used below to drive the iteration-3 nudge.
-
-### 1f.1: Launch plan review
-
-Launch the `code-reviewer` agent using the Task tool with:
-- `subagent_type: "code-reviewer"`
-- Prompt:
-  ```
-  TASKS_DIR=$TASKS_DIR
-
-  MODE: PLAN REVIEW
-
-  Apply the five plan-review checks defined under the "Plan Review Criteria" heading in your own agent definition: (1) Dependency soundness, (2) PRD coverage gaps, (3) Task file conflicts, (4) Task sizing, (5) TDD spec consistency.
-
-  Read all `$TASKS_DIR/task-*.md` files and `$TASKS_DIR/updated-prd.md` before running the checks. Write the plan review report to `$TASKS_DIR/plan-review-report.md`. You MUST emit the `### Plan Issues Found` section with all three severity buckets (Critical / Important / Minor) — use `- None` for buckets with no issues. Do not omit the section or any sub-heading.
-  ```
-
-Wait for it to complete.
-
-### 1f.2: Present plan review results
-
-1. Read `$TASKS_DIR/plan-review-report.md`. Extract the `### Plan Issues Found` section (Critical / Important / Minor items).
-
-2. Present the plan issues summary to the user as a formatted list. If no issues were found in any category, note "No plan issues found."
-
-3. Use `AskUserQuestion` with a single question: "How would you like to proceed?"
-   - **"Proceed anyway"** — continue to Step 2 (even if issues were found)
-   - **"Regenerate with feedback"** — user provides feedback via the "Other" field; the planner will regenerate task files incorporating the plan review findings and user feedback
-   - **"Edit files manually"** — user edits task files in `$TASKS_DIR/` directly, then re-runs plan review
-
-### 1f.3: Handle user choice
-
-(The `PLAN_REVIEW_ITER` counter was initialized at the top of Step 1f. Read below for how it gates the soft nudge.)
-
-**Loop guardrail — soft nudge after iteration 3.** If `PLAN_REVIEW_ITER >= 3` AND the user's choice at 1f.2 was either "Regenerate with feedback" or "Edit files manually" (i.e., any choice that will cause a loop-back to 1f.1), insert this message before proceeding with that choice: "Heads up — this is plan-review iteration N. If the reviewer keeps flagging the same class of issue, consider either editing files manually (if you haven't), picking 'Proceed anyway' and fixing at implementation time, or stopping to revise the PRD itself." Then honor the user's choice. The nudge fires on every looping iteration from N=3 onward, not just once. Do not hard-cap the loop.
-
-**If "Proceed anyway"**:
-Log "Plan review issues noted. Proceeding to implementation." Continue to Step 2. This is a valid exit regardless of whether issues remain.
-
-**If "Regenerate with feedback"**:
-
-1. Collect the user's feedback from their `AskUserQuestion` response (the "Other" field).
-2. **Validate feedback is non-empty.** If the user picked "Regenerate with feedback" but left the "Other" field blank (or provided only whitespace), re-prompt via `AskUserQuestion`: "Regeneration needs either specific feedback or a direction. Provide feedback, or switch to 'Edit files manually' / 'Proceed anyway'." Do not resume the planner with an empty feedback block — it has no new signal to work from and will likely produce a near-identical plan.
-3. Read `$TASKS_DIR/plan-review-report.md` and extract the `### Plan Issues Found` section contents (the reviewer's output contract guarantees this section exists).
-4. Resume the **same** `prd-task-planner` agent (agent ID from Step 1a) with:
-   - `resume: "<agent-id-from-step-1a>"`
-   - Prompt: `TASKS_DIR=$TASKS_DIR\n\nMODE: GENERATE\n\nPlan review found issues requiring changes. User feedback:\n<feedback text collected in step 1>\n\nPlan review findings:\n<contents of "### Plan Issues Found" section extracted in step 3>\n\nPlease regenerate the task files addressing these issues.`
-5. Wait for regeneration to complete.
-6. Increment `PLAN_REVIEW_ITER` and **loop back to the top of Step 1f.1** — re-run the plan review on the new task files.
-
-**If "Edit files manually"**:
-
-1. Display: "Edit the files in `$TASKS_DIR/` directly. When done, reply to continue."
-2. Wait for user confirmation.
-3. Increment `PLAN_REVIEW_ITER` and **loop back to the top of Step 1f.1** — re-run the plan review against the edited files.
-
-**Loop exit conditions.** The loop exits whenever the user selects "Proceed anyway" at Step 1f.2, regardless of iteration count or remaining issues. A clean review ("No plan issues found") still requires the user to confirm via "Proceed anyway" — the skill does not auto-advance. There is no hard retry cap.
+The planner runs a structural self-check (dependency soundness, file conflicts, PRD coverage, sizing, TDD consistency) before returning, so no separate plan-review pass is needed. If the planner found ambiguities it could not resolve, they will appear in `$TASKS_DIR/updated-prd.md` under an `## Open Questions` section — the user already saw these in Step 1d.
 
 ## Step 2: Implement
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -20,124 +20,74 @@ $ARGUMENTS
 
 ## Step 0.05: PRD adequacy check
 
-Before any planning, gauge whether the input PRD has enough substance for the planner to work with. Read the parsed PRD content (or the file at the path provided in `$ARGUMENTS`).
+**Skip if `--brainstorm` was passed** — brainstorm mode is itself a form of pre-planning sharpening.
 
-**Skip this step entirely if `--brainstorm` was passed.** Brainstorm mode is itself a form of pre-planning sharpening — the user has explicitly asked for options to be proposed.
+Treat the PRD as underspecified if any of: shorter than ~3 sentences; expresses a desire without naming user-facing behavior/scope/success criteria; contains hedges ("not sure if...", "maybe..."); the chat session has no prior design context.
 
-**Treat the PRD as underspecified if any are true:**
-- It is shorter than ~3 sentences
-- It expresses a desire ("I want to...", "we should...") without naming user-facing behavior, scope, or success criteria
-- It contains explicit hedges ("not sure if...", "maybe...", "something like...")
-- The current chat session has no prior context indicating the design has been worked through (no prior grilling, no design doc shared, no answered clarifying questions)
+If underspecified, check the repo root for `CONTEXT.md` / `CONTEXT-MAP.md` and offer via `AskUserQuestion`:
+- **"Run `/grill-with-docs` first"** (only when CONTEXT doc detected)
+- **"Run `/grill-me` first"**
+- **"Continue anyway"** — proceed; planner discovery picks up the slack
+- **"Switch to `--brainstorm`"**
 
-**If underspecified:**
-
-1. Detect domain docs at the repo root: check whether `CONTEXT.md` (single-context) or `CONTEXT-MAP.md` (multi-context) exists.
-
-2. Use `AskUserQuestion`:
-   - Question: "The PRD is sparse. Grilling first usually catches misalignment cheaper than the planner does. How do you want to proceed?"
-   - Options:
-     - **"Run `/grill-with-docs` first"** (only offer when `CONTEXT.md` or `CONTEXT-MAP.md` was detected) — stop the build pipeline; user re-runs `/build` after grilling
-     - **"Run `/grill-me` first"** — stop the build pipeline; user re-runs `/build` after grilling
-     - **"Continue anyway"** — proceed; the planner's discovery phase will pick up the slack
-     - **"Switch to `--brainstorm`"** — re-run `/build` with the `--brainstorm` flag to get design options proposed instead
-
-3. If the user picks a grill or brainstorm option, exit cleanly with a message like: "Stopping `/build`. Re-run with the sharpened PRD when grilling is complete." Do not invoke the chosen skill yourself — the user re-invokes manually so the grilling session has a clean context.
-
-4. If the user picks "Continue anyway", proceed to Step 0.1.
-
-**If the PRD is adequate:** proceed directly to Step 0.1.
+For grill/brainstorm choices, exit cleanly: "Stopping `/build`. Re-run after sharpening." Do not invoke the chosen skill yourself — the user re-invokes manually so the grilling session has a clean context. For "Continue anyway", proceed to Step 0.1.
 
 ## Step 0.1: Auto-commit opt-in
 
-Ask: "Enable auto-commit and PR?" (Yes / No) → `AUTO_COMMIT`.
+Ask: "Enable auto-commit and PR?" → `AUTO_COMMIT`. If false: set `BRANCH_ACTION=none`, `COMMIT_MODE=none`, skip to Step 0.1b.
 
-**If `AUTO_COMMIT=true`:**
-1. Run `git rev-parse --abbrev-ref HEAD` to get `CURRENT_BRANCH`. If `CURRENT_BRANCH` is `main` or `master`: `BRANCH_ACTION=new`. Else ask: "Branch `<name>` exists — create new or commit here?" → `BRANCH_ACTION=new/current`.
-2. Ask: "How should changes be committed?"
-   - **Squash** — single commit at the end summarizing all changes
-   - **Per-wave** — one commit per parallel execution wave (e.g., Wave 1: 3 tasks → 1 commit)
-   - **Per-task at end** — full parallel run, then one atomic commit per task in order
-   → `COMMIT_MODE=squash/per-wave/per-task-at-end`
-3. Generate `feat/<3-5-word-slug>` from PRD content → `AUTO_COMMIT_BRANCH`.
-4. **If `BRANCH_ACTION=new`:**
-   - Run `git fetch origin` to get latest remote state.
-   - Detect default branch: run `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'`. If empty or error, default to `main`. Store as `DEFAULT_BRANCH`.
-   - Ask: "Which branch should `<AUTO_COMMIT_BRANCH>` be based on?"
-     - Option 1: `<DEFAULT_BRANCH>` (remote default)
-     - Option 2: `<CURRENT_BRANCH>` (current branch)
-     - Option 3: Other (enter branch name)
-   - Store chosen base as `BASE_BRANCH`.
-   - **Do not create the branch yet** — Step 0.1b performs the actual `git checkout -b` or `git worktree add -b` based on the worktree choice.
-
-**If `AUTO_COMMIT=false`:** `BRANCH_ACTION=none`, `COMMIT_MODE=none`.
+If true:
+1. `CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)`. If `main`/`master`: `BRANCH_ACTION=new`. Else ask: "Branch `<name>` exists — create new or commit here?" → `BRANCH_ACTION=new|current`.
+2. Ask commit mode → `COMMIT_MODE=squash|per-wave|per-task-at-end`:
+   - **squash** — single commit at the end
+   - **per-wave** — one commit per parallel execution wave
+   - **per-task-at-end** — parallel run, then one atomic commit per task in order
+3. Generate `feat/<3-5-word-slug>` from PRD → `AUTO_COMMIT_BRANCH`.
+4. If `BRANCH_ACTION=new`:
+   - `git fetch origin`; `DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')` (fallback `main`).
+   - Ask which branch to base on: `DEFAULT_BRANCH` / `CURRENT_BRANCH` / Other → `BASE_BRANCH`.
+   - **Do not create the branch yet** — Step 0.1b creates it via `git checkout -b` or `git worktree add -b` depending on the worktree choice.
 
 ## Step 0.1b: Worktree opt-in and branch creation
 
-Ask: "Run workflow in a new git worktree? (enables running multiple pipelines in parallel in the same project)" (Yes / No) → `USE_WORKTREE`.
+Ask: "Run workflow in a new git worktree?" → `USE_WORKTREE`. Default `WORKTREE_PATH=""` (set only if a worktree is created).
 
-Store `WORKTREE_PATH=""` as the default. It is set to the new worktree's relative path only if one is created.
+**If `USE_WORKTREE=false`:**
+- If `AUTO_COMMIT=true` AND `BRANCH_ACTION=new`: `git checkout -b <AUTO_COMMIT_BRANCH> <BASE_BRANCH>` (on failure append `-2` and retry once).
+- Otherwise: no-op. Proceed to Step 0.2.
 
-### If `USE_WORKTREE=false`:
+**If `USE_WORKTREE=true`:**
 
-- **If `AUTO_COMMIT=true` AND `BRANCH_ACTION=new`**: run `git checkout -b <AUTO_COMMIT_BRANCH> <BASE_BRANCH>`. On failure append `-2` to `AUTO_COMMIT_BRANCH`, retry once.
-- Otherwise: take no action here. Continue to Step 0.2.
+1. If `AUTO_COMMIT=true` AND `BRANCH_ACTION=current`: worktrees can't share a branch. Ask: "Switch to a new branch, or skip the worktree?"
+   - "Create new branch" → set `BRANCH_ACTION=new`, generate `AUTO_COMMIT_BRANCH=feat/<slug>` if not already, repeat the base-branch Q&A from Step 0.1 step 4.
+   - "Skip worktree" → set `USE_WORKTREE=false` and use the false branch above.
 
-### If `USE_WORKTREE=true`:
+2. Resolve `WT_BRANCH` and `WT_BASE`:
+   - If `AUTO_COMMIT=true`: `WT_BRANCH=$AUTO_COMMIT_BRANCH`, `WT_BASE=$BASE_BRANCH`.
+   - Else: ask for branch name (suggest `feat/<slug>`), then run the same `git fetch origin` + base-branch Q&A.
 
-1. **If `AUTO_COMMIT=true` AND `BRANCH_ACTION=current`**: worktrees require a fresh branch (git disallows two worktrees on the same branch). Ask: "Worktree needs a new branch. Switch to a new branch, or skip the worktree and commit on the current branch?"
-   - **"Create new branch"** → set `BRANCH_ACTION=new`. Generate `AUTO_COMMIT_BRANCH=feat/<3-5-word-slug>` from the PRD content if not already generated. Run the same base-branch Q&A as Step 0.1 step 4 to pick `BASE_BRANCH`.
-   - **"Skip worktree"** → set `USE_WORKTREE=false` and fall through to the `USE_WORKTREE=false` branch above.
+3. Sanitize `$WT_BRANCH` to a filesystem-safe path segment (`/`→`-`, strip non-`[A-Za-z0-9._-]`, trim dashes) → `WT_PATH_SEG`.
 
-2. Resolve the worktree branch and base:
-   - **If `AUTO_COMMIT=true`**: `WT_BRANCH=$AUTO_COMMIT_BRANCH`, `WT_BASE=$BASE_BRANCH` (both set in Step 0.1).
-   - **If `AUTO_COMMIT=false`**:
-     - Ask: "Branch name for the worktree?" Suggest `feat/<3-5-word-slug>` derived from the PRD content. Store as `WT_BRANCH`.
-     - Run `git fetch origin` and detect `DEFAULT_BRANCH` (same as Step 0.1 step 4).
-     - Get `CURRENT_BRANCH` if not already set.
-     - Ask: "Which branch should `<WT_BRANCH>` be based on?" with the same three options (default / current / other). Store as `WT_BASE`.
+4. `git worktree add -b "$WT_BRANCH" ".claude-worktrees/$WT_PATH_SEG" "$WT_BASE"`. On collision append `-2` to both and retry once; if still failing, abort. If the retry succeeded and `AUTO_COMMIT=true`, set `AUTO_COMMIT_BRANCH=$WT_BRANCH` so downstream steps target the renamed branch.
 
-3. Sanitize `$WT_BRANCH` into a filesystem-safe path segment (same rules as Step 0a's `SANITIZED`): replace `/` with `-`, strip non-`[A-Za-z0-9._-]`, trim leading/trailing dashes. Store as `WT_PATH_SEG`.
-
-4. Create the worktree and branch atomically:
-   ```bash
-   git worktree add -b "$WT_BRANCH" ".claude-worktrees/$WT_PATH_SEG" "$WT_BASE"
-   ```
-   On failure (branch or path already exists), append `-2` to both `$WT_BRANCH` and `$WT_PATH_SEG` and retry once. If it still fails, abort with a clear error to the user. **If the retry succeeds and `AUTO_COMMIT=true`, set `AUTO_COMMIT_BRANCH=$WT_BRANCH`** so downstream commit/push/PR/report steps target the renamed branch.
-
-5. `cd ".claude-worktrees/$WT_PATH_SEG"`. All subsequent steps run inside the worktree.
-
-6. Set `WORKTREE_PATH=".claude-worktrees/$WT_PATH_SEG"` for the final report.
+5. `cd ".claude-worktrees/$WT_PATH_SEG"`. Set `WORKTREE_PATH=".claude-worktrees/$WT_PATH_SEG"` for the final report. All subsequent steps run inside the worktree.
 
 ## Step 0.2: Orchestration Mode Selection
 
-Check for a saved orchestration mode preference:
-- Run: `cat ~/.claude/user-preferences.json 2>/dev/null`
-- If the file exists and contains an `"orchestrationMode"` key:
-  - Log: "Using saved orchestration mode: `<value>`"
-  - Set `ORCHESTRATION_MODE` to the saved value (`parallel` or `agent-teams`)
-  - Skip the rest of this step and proceed to Step 0.
+Check `~/.claude/user-preferences.json` for `"orchestrationMode"` — if present, set `ORCHESTRATION_MODE` to its value (`parallel` or `agent-teams`) and skip the rest of this step.
 
-If no saved preference, ask the user which orchestration mode to use:
+Otherwise ask via `AskUserQuestion` ("How should tasks be implemented?"):
+- **Default (Recommended)**: `parallel` — sub-agent approach with wave-based parallel execution
+- **Agent Teams (Beta)**: `agent-teams` — Claude Code's native Agent Teams feature
 
-Use `AskUserQuestion` with:
-- Question: "How should tasks be implemented?"
-- Options:
-  - **Default (Recommended)**: Use `parallel-task-orchestrator` — proven sub-agent approach with wave-based parallel execution
-  - **Agent Teams (Beta)**: Use Claude Code's native Agent Teams feature — separate sessions coordinating via shared task list
-
-Store the result as `ORCHESTRATION_MODE` (`parallel` or `agent-teams`).
-
-Then ask: "Save this as your default orchestration mode?" (Yes / No).
-
-If Yes: run this command, replacing `<ORCHESTRATION_MODE>` with the actual value (`parallel` or `agent-teams`):
+Then ask: "Save as default?" If yes, persist to `~/.claude/user-preferences.json`:
 ```bash
 MODE=<ORCHESTRATION_MODE> python3 -c "
 import json, os
-path = os.path.expanduser('~/.claude/user-preferences.json')
-prefs = json.load(open(path)) if os.path.exists(path) else {}
+p = os.path.expanduser('~/.claude/user-preferences.json')
+prefs = json.load(open(p)) if os.path.exists(p) else {}
 prefs['orchestrationMode'] = os.environ['MODE']
-json.dump(prefs, open(path, 'w'), indent=2)
+json.dump(prefs, open(p, 'w'), indent=2)
 "
 ```
 
@@ -170,145 +120,72 @@ Store `TASKS_DIR` as a session variable — use it everywhere below.
 Use Bash to run `rm -rf "$TASKS_DIR"` to clear only this branch's task directory.
 This prevents stale task files from being picked up by the orchestrator.
 
-## Step 0.5 (if BRAINSTORM=true): Design brainstorm
+## Step 0.5: Design brainstorm (only if BRAINSTORM=true)
 
-**Skip this step if BRAINSTORM=false.**
+Launch `prd-task-planner` with `subagent_type: "prd-task-planner"` and prompt `TASKS_DIR=$TASKS_DIR\nMODE: BRAINSTORM\n\n<clean PRD content>`. **Save the returned agent ID** — this same agent will be resumed in Step 1a.
 
-1. Launch the `prd-task-planner` agent using the Task tool with:
-   - `subagent_type: "prd-task-planner"`
-   - Prompt:
-     ```
-     TASKS_DIR=$TASKS_DIR
-     MODE: BRAINSTORM
-
-     <clean PRD content>
-     ```
-   - Wait for it to complete. **Save the returned agent ID** — this agent will be resumed in Step 1a.
-
-2. Read `$TASKS_DIR/design-options.md`.
-
-3. Present the design options to the user using `AskUserQuestion`. Build one question per option listed in the file, using the option names as labels and their summaries/trade-offs as descriptions. Include a "Custom direction" option. Ask: "Which design approach should we use for this feature?"
-
-4. Collect the user's chosen option. Store it as `CHOSEN_DESIGN`.
+Read `$TASKS_DIR/design-options.md`. Present each option via `AskUserQuestion` (option name → label, summary/trade-offs → description). Include a "Custom direction" option. Store the chosen option as `CHOSEN_DESIGN`.
 
 ## Step 1: Plan — Two-phase planning with user Q&A
 
 ### Step 1a: Discovery — Explore codebase & surface questions
 
-**If BRAINSTORM=true** — resume the agent from Step 0.5:
-- `resume: "<agent-id-from-step-0.5>"`
-- Prompt:
-  ```
-  TASKS_DIR=$TASKS_DIR
-  MODE: DISCOVERY
+If `BRAINSTORM=true`: resume the agent from Step 0.5 with `MODE: DISCOVERY\nChosen design direction: <CHOSEN_DESIGN>\n\n<clean PRD content>`. The agent already has codebase context and will skip re-exploration.
 
-  Chosen design direction: <CHOSEN_DESIGN>
+If `BRAINSTORM=false`: launch fresh with `subagent_type: "prd-task-planner"` and `TASKS_DIR=$TASKS_DIR\nMODE: DISCOVERY\n\n<PRD content>`.
 
-  <clean PRD content>
-  ```
-- Tell it to output questions to `$TASKS_DIR/planning-questions.md`
-- The agent already has full codebase context from the brainstorm phase — it will skip re-exploration.
+Either way, tell it to output questions to `$TASKS_DIR/planning-questions.md`. **Save the returned agent ID** — you will resume this same agent in Step 1c.
 
-**If BRAINSTORM=false** — launch a fresh agent:
-- `subagent_type: "prd-task-planner"`
-- Prompt:
-  ```
-  TASKS_DIR=$TASKS_DIR
-  MODE: DISCOVERY
+### Step 1b: User Q&A
 
-  <PRD content>
-  ```
-- Tell it to output questions to `$TASKS_DIR/planning-questions.md`
-
-Wait for it to complete. **Save the returned agent ID** — you will resume this agent in Step 1c.
-
-### Step 1b: User Q&A — Present questions and collect answers
-
-1. Read `$TASKS_DIR/planning-questions.md`
-2. Present each question to the user using `AskUserQuestion` — use the questions, context, and options from the file to construct clear choices
-3. Collect all answers
+Read `$TASKS_DIR/planning-questions.md`. Present each question to the user via `AskUserQuestion` (use the file's questions, context, and options). Collect all answers.
 
 ### Step 1c: Generate — Resume planner with answers
 
-Resume the **same** prd-task-planner agent (using the agent ID from Step 1a) with:
-- `resume: "<agent-id-from-step-1a>"`
-- Provide all user answers in the prompt, formatted clearly
-- Prepend `MODE: GENERATE` to the prompt
-- Tell it to generate the updated PRD and task files in `$TASKS_DIR/`
-
-Wait for it to complete. Confirm that task files were created in `$TASKS_DIR/`.
+Resume the **same** agent from Step 1a with `MODE: GENERATE` prepended, the formatted user answers, and instruction to generate `$TASKS_DIR/updated-prd.md` and the task files. Wait, then confirm task files were created.
 
 ### Step 1d: Task review — Present plan and get approval
 
-This step always runs. Do not skip it.
+Always runs. Read all `task-*.md` files; for each, extract task number, title, `## Objective` first line, and `## Dependencies`. Present as:
 
-1. Read all `task-*.md` files from `$TASKS_DIR/`. For each, extract:
-   - Task number and title (from filename or `# Task N:` heading)
-   - Objective (first line of `## Objective` section)
-   - Dependencies (from `## Dependencies` section)
+```
+## Task Plan (N tasks)
 
-2. Present the full task plan to the user as a formatted list:
-   ```
-   ## Task Plan (N tasks)
+1. task-01-name — [Objective]
+   Dependencies: None
+2. task-02-name — [Objective]
+   Dependencies: task-01
+...
+```
 
-   1. task-01-name — [Objective]
-      Dependencies: None
-   2. task-02-name — [Objective]
-      Dependencies: task-01
-   ...
-   ```
-   Then add: "You can also open and edit any file in `$TASKS_DIR/` directly before proceeding."
+Add: "You can also open and edit any file in `$TASKS_DIR/` directly before proceeding."
 
-3. Use `AskUserQuestion` with a single question: "How would you like to proceed?"
-   - **"Looks good — start implementation"** — continue to Step 1e
-   - **"Regenerate with feedback"** — user provides feedback via the "Other" field
-
-4. **If user approves**: proceed to Step 1e.
-
-5. **If user requests regeneration**: resume the **same** prd-task-planner agent (from Step 1a/1c) with:
-   - `resume: "<agent-id-from-step-1a>"`
-   - Prompt: `MODE: GENERATE\n\nUser feedback on the task plan:\n<feedback>\n\nPlease regenerate the task files incorporating this feedback.`
-   - Wait for it to complete, then **loop back to the top of Step 1d** to re-present the updated plan.
+Use `AskUserQuestion`: "How would you like to proceed?"
+- **"Looks good — start implementation"** → Step 1e
+- **"Regenerate with feedback"** → resume the same `prd-task-planner` agent (ID from Step 1a) with `MODE: GENERATE\n\nUser feedback on the task plan:\n<feedback>\n\nPlease regenerate the task files incorporating this feedback.`, wait, then loop back to the top of Step 1d.
 
 ## Step 1e: Fast-path detection — Should we skip the orchestrator?
 
-Before launching the orchestrator, analyze the task files to determine if orchestration overhead is justified.
+Read all `$TASKS_DIR/task-*.md` files and classify `FAST_PATH=true` if ANY of:
+- 2 or fewer tasks (regardless of dependencies)
+- All tasks are sequential: linear dependency chain OR all tasks touch overlapping files (no parallelism possible)
+- Only 1 task out of 3+ could run in parallel (orchestrator adds overhead for negligible parallelism)
 
-**Read all `$TASKS_DIR/task-*.md` files and extract:**
-1. Total task count
-2. Per-task: files to modify (from `## Files to Modify` or `## Context Files` sections)
-3. Per-task: explicit dependencies (from `## Dependencies` or `Depends on:` lines)
+Otherwise `FAST_PATH=false` (3+ tasks with real parallelism opportunities).
 
-**Classify as `FAST_PATH=true` if ANY of these conditions are met:**
-- **2 or fewer tasks** (regardless of dependencies)
-- **All tasks are sequential**: every task depends on the previous one (linear chain), OR all tasks touch overlapping files (no parallelism possible)
-- **Most tasks are sequential**: only 1 task out of 3+ could run in parallel (orchestrator adds overhead for negligible parallelism)
-
-**Set `FAST_PATH=false` otherwise** (3+ tasks with real parallelism opportunities).
-
-The planner runs a structural self-check (dependency soundness, file conflicts, PRD coverage, sizing, TDD consistency) before returning, so no separate plan-review pass is needed. If the planner found ambiguities it could not resolve, they will appear in `$TASKS_DIR/updated-prd.md` under an `## Open Questions` section — the user already saw these in Step 1d.
+The planner already self-checked dependency soundness, file conflicts, PRD coverage, sizing, and TDD consistency before returning — no separate plan-review pass is needed. Unresolved ambiguities (if any) appear in `$TASKS_DIR/updated-prd.md` under `## Open Questions`, which the user saw in Step 1d.
 
 ## Step 2: Implement
 
 ### Fast path (`FAST_PATH=true`) — Direct implementation
 
-> **Note**: If `ORCHESTRATION_MODE=agent-teams` was selected, inform the user: "Fast-path detected (≤2 tasks or all sequential). Using direct implementation instead of Agent Teams — orchestration overhead is not justified for simple tasks." The env var setup from Step 0.2 is skipped in fast-path mode.
+If `ORCHESTRATION_MODE=agent-teams`: inform the user "Fast-path detected — using direct implementation instead of Agent Teams; orchestration overhead is not justified." Skip the env-var setup from Step 0.2.
 
-Implement the tasks yourself, sequentially, in the current conversation context. For each task file in order:
+Implement tasks yourself, sequentially, in the current session. For each task file in order: (1) read the task file fully, (2) read referenced context files, (3) implement, (4) if `## TDD Mode` is present follow RED→GREEN→REFACTOR→VERIFY, (5) write `$TASKS_DIR/notes/task-NN.md` with Implementation Notes. After all tasks: concatenate `$TASKS_DIR/notes/task-*.md` (sorted) into `$TASKS_DIR/implementation-notes.md` with a `# Implementation Notes` header.
 
-1. Read the task file fully (objective, requirements, acceptance criteria, context files)
-2. Read all referenced context files
-3. Implement the task following the requirements and acceptance criteria
-4. If the task has a `## TDD Mode` section, follow the RED → GREEN → REFACTOR → VERIFY cycle (including test adequacy check)
-5. After each task, write a `$TASKS_DIR/notes/task-NN.md` file with the Implementation Notes for that task (Decisions / Deviations / Trade-offs / Risks). After all tasks complete, concatenate `$TASKS_DIR/notes/task-*.md` (sorted by name) into `$TASKS_DIR/implementation-notes.md` with a `# Implementation Notes` header.
-6. **If `COMMIT_MODE=per-wave`:** after completing each task, check if the current "wave" (group of sequential tasks with no parallelism in fast-path) warrants a commit. In fast-path mode, commit after each task:
-   ```bash
-   git add -A
-   git diff --staged --quiet || git commit -m "feat: <task-objective-from-task-file>"
-   ```
-   **If `COMMIT_MODE=per-task-at-end`:** skip — commits are created in Step 2.5b after all tasks complete.
+Commit handling: if `COMMIT_MODE=per-wave`, after each task run `git add -A && git diff --staged --quiet || git commit -m "feat: <task-objective>"`. If `COMMIT_MODE=per-task-at-end`, skip — commits happen in Step 2.5b.
 
-This avoids orchestrator overhead and gives you continuous context across tasks — each task benefits from seeing the work done in previous tasks without reading files cold.
+Fast path keeps continuous session context across tasks (no cold reads) and avoids the orchestrator overhead.
 
 ### Full path (`FAST_PATH=false`) — Run orchestrator
 
@@ -363,40 +240,17 @@ After the build check, run the project's full test suite to catch regressions an
 
 **2.5a Safety:** Run `git rev-parse --abbrev-ref HEAD`. If `main`/`master`: abort ("Auto-commit aborted: on main/master. Commit manually.") → proceed to Step 3.
 
-**2.5b Commit:**
+**2.5b Commit:** behavior depends on `COMMIT_MODE`.
 
-- **`COMMIT_MODE=squash`**: Read all `$TASKS_DIR/task-*.md` files. Extract the `## Objective` line from each. Run:
-  ```bash
-  git add -A
-  git commit -m "feat: <PRD summary>" -m "$(cat <<'EOF'
-  - <objective from task-01>
-  - <objective from task-02>
-  - <objective from task-03>
-  ... (one bullet per task, no cap)
-  EOF
-  )"
-  ```
-  Subject line: 72-char max. Body: one bullet per task objective, all listed (no bullet cap).
+- **squash**: read all `$TASKS_DIR/task-*.md` `## Objective` lines, then `git add -A && git commit -m "feat: <PRD summary>"` with body `-m` containing one bullet per task objective (no cap). Subject ≤72 chars.
 
-- **`COMMIT_MODE=per-wave`**: Commits were made by the orchestrator (or fast-path) during execution. Run `git add -A` to catch any unstaged changes left after the final wave, then commit any remainder:
-  ```bash
-  git add -A
-  git diff --staged --quiet || git commit -m "feat: post-run cleanup"
-  ```
-  If nothing is staged after `git add -A`, skip the final commit.
+- **per-wave**: commits already made by the orchestrator (or fast-path). `git add -A`; if anything's still staged, `git commit -m "feat: post-run cleanup"`; otherwise skip.
 
-- **`COMMIT_MODE=per-task-at-end`**: Full parallel run is complete. Now create one commit per task in task-file order:
-  1. Run `git add -A` to stage all changes.
-  2. Read each `$TASKS_DIR/task-NN-*.md` file in numerical order.
-  3. For each task, extract its `## Objective` line and the list of files it touched (from the `## Target Files` section).
-  4. Use `git restore --staged .` to unstage everything, then selectively stage only the files for this task using `git add <file1> <file2> ...`, then commit:
-     ```bash
-     git restore --staged .
-     git add <files for this task>
-     git commit -m "feat: <task objective>"
-     ```
-  5. Repeat for each task in order.
-  6. After all per-task commits, run `git add -A && git diff --staged --quiet || git commit -m "feat: miscellaneous changes"` to catch any files not covered by the task-file manifests.
+- **per-task-at-end**: parallel run is complete. For each `task-NN-*.md` in numerical order:
+  1. `git restore --staged .` to clear staging
+  2. Read the task's `## Target Files` section for its file list
+  3. `git add <file1> <file2> ...` (only that task's files), then `git commit -m "feat: <task objective>"`
+  After all per-task commits: `git add -A && git diff --staged --quiet || git commit -m "feat: miscellaneous changes"` to catch files not covered by any task's manifest.
 
 **2.5d Push:** `git push -u origin <branch-name>`. On failure, show manual command and continue.
 
@@ -408,24 +262,14 @@ After the build check, run the project's full test suite to catch regressions an
 
 ## Step 3: Review — Run code-reviewer
 
-Before launching the code-reviewer, check if TDD mode was used by reading any task file from `$TASKS_DIR/` and looking for a `## TDD Mode` section. Also check if `$TASKS_DIR/implementation-notes.md` and `$TASKS_DIR/execution-metrics.md` exist.
+Detect TDD usage by grepping any `task-*.md` for `## TDD Mode`. Note whether `$TASKS_DIR/implementation-notes.md` exists.
 
-Launch the `code-reviewer` agent using the Task tool with:
+Launch `code-reviewer` with:
 - `subagent_type: "code-reviewer"`
-- Prompt:
-  ```
-  TASKS_DIR=$TASKS_DIR
-  Review all changes against `$TASKS_DIR/updated-prd.md` and write the review report to `$TASKS_DIR/review-report.md`.
-  ```
-- **If `$TASKS_DIR/implementation-notes.md` exists**, tell it to read this file for implementer decision context
-- **If TDD mode was used**, include these additional review criteria in the prompt:
-  - Were tests written for each task that had TDD mode enabled?
-  - Do the tests meaningfully cover the acceptance criteria from the task files?
-  - Are there tasks with TDD mode that appear to be missing tests?
-  - Do tests follow project conventions?
-  - Run the test adequacy deep-check (verify each test calls the code under test, has specific assertions, and would catch real regressions)
-  - If any implementer declared "TDD not feasible", verify the reason is valid
-- **If TDD mode was not used**, still tell the reviewer to check general test coverage as part of the standard review
+- Base prompt: `TASKS_DIR=$TASKS_DIR\nReview all changes against $TASKS_DIR/updated-prd.md and write the review report to $TASKS_DIR/review-report.md.`
+- If `implementation-notes.md` exists: tell it to read this file for implementer decision context.
+- If TDD was used: tell it to apply TDD-specific review criteria (test adequacy, mocking discipline, validity of any "TDD not feasible" declarations) — the reviewer agent has those checks built in.
+- If TDD was not used: tell it to check general test coverage as part of the standard review.
 
 Wait for it to complete.
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -181,7 +181,7 @@ The planner already self-checked dependency soundness, file conflicts, PRD cover
 
 If `ORCHESTRATION_MODE=agent-teams`: inform the user "Fast-path detected — using direct implementation instead of Agent Teams; orchestration overhead is not justified." Skip the env-var setup from Step 0.2.
 
-Implement tasks yourself, sequentially, in the current session. For each task file in order: (1) read the task file fully, (2) read referenced context files, (3) implement, (4) if `## TDD Mode` is present follow RED→GREEN→REFACTOR→VERIFY, (5) write `$TASKS_DIR/notes/task-NN.md` with Implementation Notes. After all tasks: concatenate `$TASKS_DIR/notes/task-*.md` (sorted) into `$TASKS_DIR/implementation-notes.md` with a `# Implementation Notes` header.
+Implement tasks yourself, sequentially, in the current session. For each task file in order: (1) read the task file fully, (2) read referenced context files, (3) implement, (4) if `## TDD Mode` is present, follow Section B of `.claude/agents/tdd-mode.md` (RED → adequacy check → GREEN → REFACTOR → VERIFY). (5) write `$TASKS_DIR/notes/task-NN.md` with Implementation Notes — same template the `task-implementer` agent uses (Decisions / Deviations / Trade-offs / Risks; one bullet per category, or a single `No non-obvious decisions.` line if all choices were obvious). After all tasks: concatenate `$TASKS_DIR/notes/task-*.md` (sorted) into `$TASKS_DIR/implementation-notes.md` with a `# Implementation Notes` header.
 
 Commit handling: if `COMMIT_MODE=per-wave`, after each task run `git add -A && git diff --staged --quiet || git commit -m "feat: <task-objective>"`. If `COMMIT_MODE=per-task-at-end`, skip — commits happen in Step 2.5b.
 
@@ -289,15 +289,18 @@ Read `$TASKS_DIR/review-report.md`. Check if the `### Critical` section contains
    - **"Stop here"** — halt the pipeline at this point; user reviews state before deciding next move
 
 3. **If "Auto-fix"**:
-   - For each distinct file affected, launch a `task-implementer` sub-agent in parallel with:
+   - For each distinct file affected (index them as `01`, `02`, ...), launch a `task-implementer` sub-agent in parallel with:
      - `TASKS_DIR=$TASKS_DIR` so it can find shared-context
      - The specific critical issue(s) for that file verbatim from the report
      - Instruction to fix only these specific issues, touching no other code
+     - **Notes file path override**: tell the implementer to write its Implementation Notes to `$TASKS_DIR/notes/autofix-<idx>.md` (e.g., `notes/autofix-01.md`) instead of the standard `task-NN.md` path — there is no task file for auto-fix runs, so the standard NN-derivation rule does not apply.
    - Wait for all task-implementers to complete.
    - Re-run the code-reviewer (same criteria as Step 3) **once** against `$TASKS_DIR/updated-prd.md`. Write the updated report to `$TASKS_DIR/review-report.md` (overwrite).
    - Do not loop — the auto-fix runs at most once. If critical issues persist after the retry, report them in Step 4.
 
-4. **If "Skip" or "Stop here"**: proceed to Step 4 (or halt for "Stop here"). Do not spawn any sub-agents.
+4. **If "Skip — I'll fix them"**: proceed to Step 4 with issues unfixed. Do not spawn any sub-agents. The Step 4 report will list the open critical issues so the user has them in writing.
+
+5. **If "Stop here"**: halt the pipeline. Print a short state summary (branch name, tasks completed, critical-issue count, path to `$TASKS_DIR/review-report.md`) and exit cleanly. Do **not** run Step 4. Do not spawn any sub-agents. Do not commit or push.
 
 ## Step 4: Report
 

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -227,7 +227,7 @@ Refactoring task files often have linear dependency chains (rename → extract �
 
 If `ORCHESTRATION_MODE=agent-teams`: inform the user "Fast-path detected — using direct implementation instead of Agent Teams; orchestration overhead is not justified for simple refactors." Skip the env-var setup from Step 0.2.
 
-Implement tasks yourself, sequentially, in the current session. For each task file in order: (1) read the task file fully, (2) read any referenced tests, (3) apply the refactor, (4) run the test command for that task to verify behavior is preserved, (5) write `$TASKS_DIR/notes/task-NN.md` with notes on what was changed and why, anything risky for review. After all tasks: concatenate `$TASKS_DIR/notes/task-*.md` (sorted) into `$TASKS_DIR/implementation-notes.md`.
+Implement tasks yourself, sequentially, in the current session. For each task file in order: (1) read the task file fully, (2) read any referenced tests, (3) apply the refactor, (4) run **the project test command** (the same one Step 1.5 used to write the safety net, or whichever command the task file specifies) to verify behavior is preserved — refactor tasks rarely have their own per-task test commands; the safety net is the verification surface, (5) write `$TASKS_DIR/notes/task-NN.md` with notes on what was changed and why, plus anything risky for review (Decisions / Deviations / Trade-offs / Risks). After all tasks: concatenate `$TASKS_DIR/notes/task-*.md` (sorted) into `$TASKS_DIR/implementation-notes.md` with a `# Implementation Notes` header.
 
 Commit handling: if `COMMIT_MODE=per-wave`, after each task run `git add -A && git diff --staged --quiet || git commit -m "refactor: <task-objective>"`. If `COMMIT_MODE=per-task-at-end`, skip — commits happen in Step 2.5b.
 

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -208,9 +208,32 @@ Launch the `test-writer` agent using the Task tool with:
 - `subagent_type: "test-writer"`
 - Prompt: `Write tests for <target> to create a safety net before refactoring. Focus on covering the behavior that the refactoring tasks will touch.`
 
-Wait for it to complete, then read the test-writer's final output. It reports whether the tests it wrote pass. If all tests pass, proceed to Step 2. If any test fails, do NOT proceed — surface the failures to the user and ask whether to abort or to fix the failing tests first.
+Wait for it to complete, then read the test-writer's final output. It reports whether the tests it wrote pass. If all tests pass, proceed to Step 1.6. If any test fails, do NOT proceed — surface the failures to the user and ask whether to abort or to fix the failing tests first.
 
-## Step 2: Implement — Run orchestrator
+## Step 1.6: Fast-path detection — Should we skip the orchestrator?
+
+Read all `$TASKS_DIR/task-*.md` files and classify `FAST_PATH=true` if ANY of:
+- 2 or fewer tasks (regardless of dependencies)
+- All tasks are sequential: linear dependency chain OR all tasks touch overlapping files (no parallelism possible)
+- Only 1 task out of 3+ could run in parallel (orchestrator adds overhead for negligible parallelism)
+
+Otherwise `FAST_PATH=false`.
+
+Refactoring task files often have linear dependency chains (rename → extract → simplify → decompose) and tend toward fast-path more than feature builds.
+
+## Step 2: Implement
+
+### Fast path (`FAST_PATH=true`) — Direct implementation
+
+If `ORCHESTRATION_MODE=agent-teams`: inform the user "Fast-path detected — using direct implementation instead of Agent Teams; orchestration overhead is not justified for simple refactors." Skip the env-var setup from Step 0.2.
+
+Implement tasks yourself, sequentially, in the current session. For each task file in order: (1) read the task file fully, (2) read any referenced tests, (3) apply the refactor, (4) run the test command for that task to verify behavior is preserved, (5) write `$TASKS_DIR/notes/task-NN.md` with notes on what was changed and why, anything risky for review. After all tasks: concatenate `$TASKS_DIR/notes/task-*.md` (sorted) into `$TASKS_DIR/implementation-notes.md`.
+
+Commit handling: if `COMMIT_MODE=per-wave`, after each task run `git add -A && git diff --staged --quiet || git commit -m "refactor: <task-objective>"`. If `COMMIT_MODE=per-task-at-end`, skip — commits happen in Step 2.5b.
+
+Fast-path keeps continuous session context across tasks (no cold reads) and avoids the orchestrator overhead, which is rarely justified for refactors with sequential dependencies.
+
+### Full path (`FAST_PATH=false`) — Run orchestrator
 
 **If `ORCHESTRATION_MODE=parallel`** (default):
 
@@ -224,8 +247,6 @@ Launch the `parallel-task-orchestrator` agent using the Task tool with:
 Wait for it to complete. Note any issues reported.
 
 **If `ORCHESTRATION_MODE=agent-teams`** (Beta):
-
-> **Note**: If the refactor pipeline adds fast-path detection in the future, the same override logic as the build SKILL should apply — inform the user that Agent Teams mode is skipped for simple tasks.
 
 First, enable the required env var by finding the user's settings file (check `.claude/settings.local.json`, then `.claude/settings.json`, then `~/.claude/settings.json`) and adding `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` to the `env` object, preserving all existing settings. If no settings file exists, create `.claude/settings.local.json` with the env var.
 
@@ -326,7 +347,7 @@ Wait for it to complete.
 
 Summarize the full refactoring run to the user:
 
-Check if `$TASKS_DIR/execution-metrics.md` exists (produced by the orchestrator). Use it to populate the metrics section.
+Check if `$TASKS_DIR/execution-metrics.md` exists (produced by the orchestrator in full-path mode). If not (fast-path mode), generate equivalent metrics inline from your own execution.
 
 ```
 ## Refactor Complete

--- a/setup.sh
+++ b/setup.sh
@@ -179,6 +179,7 @@ CLAUDE_FILES=(
   ".claude/agents/qa-agent.md"
   ".claude/agents/refactor-planner.md"
   ".claude/agents/task-implementer.md"
+  ".claude/agents/tdd-mode.md"
   ".claude/agents/test-writer.md"
   ".claude/skills/build/SKILL.md"
   ".claude/skills/craft-pr/SKILL.md"


### PR DESCRIPTION
## Summary

Cuts typical `/build` token cost by ~50% and `/refactor` by ~30–60% on small refactors. No quality regression: Step 3 final review and Step 1d task-plan approval (the two real safety nets) are untouched. The pipeline becomes simpler — the only unbounded loop is removed and a hidden auto-spawn becomes opt-in.

## Changes (one commit per item, in order)

1. **`feat(build): promote planner to opus + drop plan-review loop`**
   - `prd-task-planner` → `model: opus`
   - Adds Phase 4 self-check in GENERATE mode (deps, file conflicts, PRD coverage, sizing, TDD consistency)
   - Deletes Step 1f from `build/SKILL.md` entirely (loop, iteration counter, soft nudge)
   - Saves 1–3 `code-reviewer` plan-review spawns per run + removes the only unbounded loop

2. **`feat(build): make Step 3b auto-fix opt-in via AskUserQuestion`**
   - Critical issues now prompt the user (Auto-fix / Skip / Stop) instead of silently spawning fixers + a re-review
   - Saves ~15–25K tokens whenever critical issues exist (which is often)

3. **`feat(build,refactor): file-based implementation notes`**
   - `task-implementer` (and Agent Teams teammate) writes notes to `$TASKS_DIR/notes/task-NN.md` instead of returning them
   - `parallel-task-orchestrator` and `agent-teams-orchestrator` concatenate files at completion instead of scraping return values
   - Saves 30–80K tokens on multi-task builds (largest single win)

4. **`refactor(code-reviewer): trim 347 → 182 lines`**
   - Drops the entire Plan Review Criteria section (dead code after #1)
   - Compresses 9 severity examples to 3 (one per tier)
   - Unifies three top-level report templates into one base + two conditional addenda

5. **`refactor(build): trim SKILL.md from 502 → 355 lines`**
   - Compresses Step 0.05 / 0.1 / 0.1b / 0.2 / 0.5 / 1a-d / 1e / 2 fast-path / 2.5b / 3 in place
   - Extraction was ruled out because the global `Read(**/build/**)` deny-rule would block sub-agent reads of any external file under `.claude/skills/build/`

6. **`feat(refactor): add fast-path detection mirroring /build Step 1e`**
   - `/refactor` Step 1.6 classifies `FAST_PATH=true` for ≤2 tasks or all-sequential plans
   - Step 2 branches on `FAST_PATH`; fast-path implements inline without spawning the orchestrator
   - Refactor plans tend toward linear chains (rename → extract → simplify), so this triggers often

7. **`refactor(agents): externalize TDD-specific instructions to tdd-mode.md`**
   - 45 lines of TDD workflow + 25 lines of TDD task-file template moved to `.claude/agents/tdd-mode.md`
   - `task-implementer` reads it only when the task file has `## TDD Mode`; `prd-task-planner` only when TDD was requested
   - Non-TDD builds (most of them) never load it
   - `setup.sh` `CLAUDE_FILES` updated to ship the new file

## Net diff

```
9 files changed, 347 insertions(+), 668 deletions(-)
```

## Quality preservation

- **Step 1d** (user task-plan approval) — untouched
- **Step 2c** (test verification) — untouched
- **Step 3** (final code review against the actual diff) — untouched; this is the primary independent-review safety net
- **Planner self-check** replaces the mechanical parts of plan review; Opus uplift covers the judgment parts
- **Auto-fix** is now opt-in but available — users retain agency on critical issues

## Test plan

- [ ] Run `/build` end-to-end on a small feature (3–4 tasks, no TDD) and verify the pipeline completes without errors
- [ ] Run `/build --brainstorm` to confirm the brainstorm → discovery → generate flow still resumes the same agent
- [ ] Run `/build` with TDD requested and verify task files include the `## TDD Mode` section copied from `tdd-mode.md`
- [ ] Run `/refactor` on a single-file target and confirm fast-path triggers (no orchestrator spawn)
- [ ] Trigger a build with critical review issues and confirm the AskUserQuestion gate appears at Step 3b
- [ ] Confirm `$TASKS_DIR/notes/task-NN.md` files are written by implementers and concatenated into `implementation-notes.md`
- [ ] Verify `setup.sh` ships `tdd-mode.md` to `~/.claude/agents/` on global update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized test-driven development workflow with integrated setup support.
  * Enhanced code review process with comprehensive quality checks and detailed reporting.

* **Improvements**
  * Reorganized implementation notes collection into a structured file-based system.
  * Streamlined planning and task execution workflows with improved orchestration.
  * Simplified user preferences persistence for workflow mode selection.

* **Documentation**
  * Updated agent instructions and skill pipelines with refined execution flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->