### PR TITLE
feat: integrate /simplify into build and refactor pipelines

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -52,6 +52,8 @@ For every requirement: find the implementation, verify it's correct and complete
 - **Performance** — N+1 queries, missing indexes, unbounded rendering, large bundle adds
 - **Test coverage** — tests exist for new/changed code? existing tests still pass? edge cases and error paths covered? naming conventions match?
 
+**Simplify-aware mode** — if your prompt states that a `/simplify` cleanup or polish pass already ran on these changes, do NOT raise Minor issues for reuse, simplification, efficiency, or altitude — those dimensions were already handled and re-flagging them is noise. Still raise them at **Critical** or **Important** severity if a genuine correctness, security, or maintainability problem hides behind one (e.g. a "simplification" that changed behavior). This suppression applies only to the Minor tier and only to those four quality dimensions.
+
 If TDD-specific criteria are in your prompt, also check:
 - Tests exist for each TDD task and meaningfully validate acceptance criteria (not `expect(true).toBe(true)`-style assertions)
 - Tests written as specs (testing behavior) rather than after-the-fact verification

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -234,6 +234,24 @@ After the build check, run the project's full test suite to catch regressions an
 - If tests fail: report the failures and ask whether to proceed, fix, or skip
 - If no test infrastructure is detected, skip this step
 
+## Step 2d: Simplify — Quality cleanup pass (opt-in, one pass)
+
+A `/simplify` pass applies reuse/simplification/efficiency/altitude cleanups to the changes. It **mutates code**, so it must run against a verified-green baseline and re-verify afterward.
+
+**Guard:** Only offer this step if Step 2c passed (or was skipped with no detected failures). If Step 2c reported failures the user chose to proceed past, **skip this step entirely** — never simplify on a red baseline. Set `SIMPLIFY_RAN=false`.
+
+1. Use `AskUserQuestion`: "Run a `/simplify` quality cleanup pass on the changes before review?"
+   - **"Yes — simplify"** — run the cleanup pass
+   - **"No — skip"** → set `SIMPLIFY_RAN=false` and proceed to Step 2.5
+
+2. **If "Yes"**: invoke the `simplify` skill via the Skill tool. Tell it to scope to the full branch diff against the base branch, so changes already committed in `per-wave`/`per-task-at-end` modes are covered — not just uncommitted edits. Wait for it to finish.
+
+3. **Re-verify behavior**: re-run the Step 2b build check command and the Step 2c test command.
+   - If something that passed before now fails, the cleanup broke behavior: report the failing checks and ask whether to (a) keep simplify's changes and continue, (b) revert the simplify changes (`git checkout -- <files>` / `git restore`) and continue, or (c) stop. Do not silently proceed.
+   - If green, set `SIMPLIFY_RAN=true`.
+
+Simplify's edits are left uncommitted and flow into the existing Step 2.5b commit logic: included in the squash commit, swept into the `per-wave` post-run cleanup commit, or caught by the `per-task-at-end` miscellaneous-changes commit.
+
 ## Step 2.5: Auto-commit and PR
 
 **Skip if `AUTO_COMMIT=false`.**
@@ -270,6 +288,7 @@ Launch `code-reviewer` with:
 - If `implementation-notes.md` exists: tell it to read this file for implementer decision context.
 - If TDD was used: tell it to apply TDD-specific review criteria (test adequacy, mocking discipline, validity of any "TDD not feasible" declarations) — the reviewer agent has those checks built in.
 - If TDD was not used: tell it to check general test coverage as part of the standard review.
+- **If `SIMPLIFY_RAN=true`**: append `A /simplify cleanup pass already ran on these changes — do NOT re-flag reuse, simplification, efficiency, or altitude items as Minor issues. Focus on correctness, PRD compliance, security, and test adequacy.` so the report stays signal-dense.
 
 Wait for it to complete.
 
@@ -324,6 +343,9 @@ Summarize the full pipeline run to the user:
 ### Testing
 - [test suite status: all passed / X failed / not detected]
 - [if TDD: TDD compliance summary]
+
+### Simplify
+- [ran — behavior re-verified green / ran — broke X, user chose Y / skipped / not offered (red baseline)]
 
 ### Execution Metrics
 - Tasks: [completed/total] | Waves: [N] | Retries: [N]

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -275,6 +275,24 @@ This step is especially critical for refactoring — the primary success criteri
 - If tests fail: report the failures and ask whether to fix, proceed anyway, or stop
 - If no test suite exists, note this prominently — behavior preservation cannot be verified automatically
 
+## Step 2d: Simplify — Final polish pass (opt-in, one pass)
+
+The refactor tasks already did the structural work (rename/extract/decompose). A `/simplify` pass is an optional final polish that catches local cleanups the tasks introduced. It **mutates code**, so behavior preservation must be re-verified — the same primary success criterion as the refactor itself.
+
+**Guard:** Only offer this step if Step 2c passed with no regressions. If tests failed or there is no test suite to verify against, **skip this step entirely** — never apply unverifiable cleanups on top of a refactor. Set `SIMPLIFY_RAN=false`.
+
+1. Use `AskUserQuestion`: "Run a `/simplify` polish pass on the refactored code before review?"
+   - **"Yes — simplify"** — run the polish pass
+   - **"No — skip"** → set `SIMPLIFY_RAN=false` and proceed to Step 2.5
+
+2. **If "Yes"**: invoke the `simplify` skill via the Skill tool. Tell it to scope to the full branch diff against the base branch, so changes already committed in `per-wave`/`per-task-at-end` modes are covered — not just uncommitted edits. Wait for it to finish.
+
+3. **Re-verify behavior preservation**: re-run the Step 2b build check and the full test suite from Step 2c.
+   - If any test that passed before now fails, the cleanup broke behavior: report the regressions and ask whether to (a) keep simplify's changes and continue, (b) revert the simplify changes (`git checkout -- <files>` / `git restore`) and continue, or (c) stop. Do not silently proceed — behavior preservation is the contract.
+   - If green, set `SIMPLIFY_RAN=true`.
+
+Simplify's edits are left uncommitted and flow into the existing Step 2.5b commit logic.
+
 ## Step 2.5: Auto-commit and PR
 
 **Skip if `AUTO_COMMIT=false`.**
@@ -340,6 +358,7 @@ Launch the `code-reviewer` agent using the Task tool with:
   - Is the code measurably cleaner, simpler, or more maintainable than before?
   - Are the changes minimal and focused — no unrelated modifications?
   - If the scope included public APIs, are signatures preserved (or are breaking changes intentional and documented)?
+- **If `SIMPLIFY_RAN=true`**: append `A /simplify polish pass already ran on these changes — do NOT re-flag reuse, simplification, efficiency, or altitude items as Minor issues. Focus on behavior preservation, correctness, and whether the code is measurably cleaner.` so the report stays signal-dense.
 
 Wait for it to complete.
 
@@ -364,6 +383,9 @@ Check if `$TASKS_DIR/execution-metrics.md` exists (produced by the orchestrator 
 
 ### Tests
 - [all passed / N regressions / no test suite]
+
+### Simplify
+- [ran — behavior preserved / ran — broke X, user chose Y / skipped / not offered (no green baseline)]
 
 ### Execution Metrics
 - Tasks: [completed/total] | Waves: [N] | Retries: [N]


### PR DESCRIPTION
## Summary

Integrates Claude Code's built-in `/simplify` skill into the `build` and `refactor` pipelines as an **opt-in quality pass**, positioned after the green test baseline and before commit/review. This means cleanups land in the feature commits (not a noisy follow-up) and the reviewer sees already-clean code, focusing its report on correctness and PRD compliance.

`code-reviewer` deliberately stays read-only — the `build` Step 3b auto-fix gate remains the only place the pipeline mutates code in response to a review, keeping re-review coherent.

## Changes

### `build/SKILL.md`
- **New Step 2d** between test verification (2c) and commit (2.5): opt-in `AskUserQuestion` gate → invoke `simplify` (scoped to the full branch diff vs base, covering already-committed changes in `per-wave`/`per-task-at-end` modes) → re-run build + tests → explicit regression handling. Guarded to skip on a red baseline.
- **Step 3** appends a "simplify already ran — don't re-flag quality Minors" instruction to the reviewer when `SIMPLIFY_RAN=true`.
- Report template gains a `### Simplify` line.

### `refactor/SKILL.md`
- Same **Step 2d**, framed as a *final polish pass* after structural tasks, with behavior-preservation re-verification as the contract (skips when there's no green test baseline).
- Matching Step 3 reviewer flag and report line.

### `code-reviewer.md`
- New **Simplify-aware mode**: suppress *Minor*-tier reuse/simplification/efficiency/altitude flags when a simplify pass already ran, while still escalating genuine correctness/security regressions hiding behind a "simplification".

## Design notes
- Simplify runs against a verified-green baseline and re-verifies after, since it mutates code.
- Commit attribution: in `per-wave`/`per-task-at-end` modes, simplify's cross-cutting edits land in the catch-all commit rather than mapped to a task — inherent to a diff-wide cleanup pass; documented in the skill.

## Test plan
- [ ] Run `/build` with the simplify step enabled; confirm it gates, applies cleanups, re-verifies, and reviewer omits quality Minors.
- [ ] Run `/build` declining the simplify step; confirm pipeline is unchanged.
- [ ] Run `/refactor` and confirm the polish pass re-verifies behavior preservation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional code simplification and quality-polish pass in build and refactor pipelines.
  * Code-review process now intelligently handles prior simplification, focusing on correctness and compliance.

* **Documentation**
  * Build and refactor completion reports now include dedicated simplification status tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nickmaglowsch/claude-setup/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->