### PR TITLE
feat: add lightweight /build-lite and /refactor-lite skills

### DIFF
--- a/.claude/skills/build-lite/SKILL.md
+++ b/.claude/skills/build-lite/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: build-lite
+description: "Lightweight build: explore → plan → approve → implement in a single Opus context, no sub-agent fan-out. Verifies build + tests, optionally commits, and offers a separate /code-review pass at the end. Use by default for everyday features; reach for /build only when the work needs parallel fan-out or exceeds one context."
+argument-hint: "<feature description or path to a PRD/spec file>"
+---
+
+# Build (Lite)
+
+Single-context build: **explore → plan → approve → implement**, all in this Opus session with **no sub-agent fan-out, no intermediate task files**. Verifies build + tests, optionally commits. Review is a separate pass — offered at the end via `/code-review`.
+
+Use this by default. Reach for the heavier `/build` only when the work spans many independent files that can be implemented in parallel, or genuinely exceeds one context (large migrations, broad sweeps).
+
+## Input
+
+`$ARGUMENTS` — a feature description, or a path to a PRD/spec file.
+
+## Step 1: Understand
+
+- Read `$ARGUMENTS`. If it points to a file, read the file.
+- Explore the relevant code **read-only** (Glob/Grep/Read) to ground the plan in the real files and conventions.
+- If the request is underspecified (no clear user-facing behavior, scope, or success criteria), ask 1–3 sharp clarifying questions via `AskUserQuestion` before planning. Don't over-ask — fill obvious gaps with sensible defaults and state them in the plan.
+
+## Step 2: Plan
+
+Present a concise plan as text:
+- One-line restatement of the goal.
+- Numbered implementation steps.
+- Files to create/modify, one-line reason each.
+- Test approach — what will prove it works.
+- Any assumptions or open questions.
+
+Then ask via `AskUserQuestion`: "Proceed with this plan?"
+- **"Proceed"** → Step 3.
+- **"Revise"** → take feedback, re-present the plan, loop.
+- **"Cancel"** → stop cleanly.
+
+Never edit code before this approval.
+
+## Step 3: Implement
+
+Implement the plan directly in this session, in dependency order. Match existing conventions (naming, structure, comment density). Keep context warm — no cold sub-agent reads, no task files. If something forces a material deviation from the approved plan, note it to the user and keep going; don't silently expand scope.
+
+## Step 4: Verify
+
+- Detect and run the build/lint command (`package.json`, `Makefile`, `Cargo.toml`, etc.). Skip if none.
+- Detect and run the test suite. If you added behavior, ensure a test covers it.
+- If build or tests fail: report the actual output and ask whether to fix now, proceed, or stop. Never claim done on a red baseline.
+
+## Step 5: Commit (optional)
+
+Ask: "Commit these changes?"
+- **No** → Step 6.
+- **Yes**:
+  - If on `main`/`master`, create a feature branch `feat/<3-5-word-slug>` first.
+  - `git add -A && git commit -m "feat: <summary>"`.
+  - Ask whether to push + open a PR. If yes and `gh` is available: `git push -u origin <branch>` then `gh pr create`. Otherwise print the ready-to-run command.
+
+## Step 6: Review handoff
+
+End with `AskUserQuestion`: "Run an independent `/code-review` pass on these changes?"
+- **"Yes"** → invoke the `code-review` skill, scoped to the diff.
+- **"No"** → print "Done. Run `/code-review` when you want an independent pass." and stop.
+
+## Rules
+- One context, no fan-out — that's the whole point. If you find yourself wanting to spawn implementers, the task is big enough for `/build`.
+- Never skip Step 2 approval before editing.
+- Report build/test failures honestly; don't claim done if it's red.

--- a/.claude/skills/refactor-lite/SKILL.md
+++ b/.claude/skills/refactor-lite/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: refactor-lite
+description: "Lightweight refactor: audit → plan → approve → implement in a single Opus context, no sub-agent fan-out. Behavior preservation is the goal — verifies tests still pass, optionally commits, and offers a separate /code-review pass at the end. Use by default; reach for /refactor only when the cleanup needs parallel fan-out or exceeds one context."
+argument-hint: "<file, directory, or description of what to improve>"
+---
+
+# Refactor (Lite)
+
+Single-context refactor: **audit → plan → approve → implement**, all in this Opus session with **no sub-agent fan-out, no intermediate task files**. Behavior preservation is the primary success criterion. Verifies tests still pass, optionally commits. Review is a separate pass — offered at the end via `/code-review`.
+
+Use this by default. Reach for the heavier `/refactor` only when the cleanup spans many independent files that can be parallelized, or genuinely exceeds one context.
+
+## Input
+
+`$ARGUMENTS` — a file, directory, or description of what to improve.
+
+## Step 1: Audit
+
+- Read the target(s). Explore surrounding code and call sites **read-only**.
+- Identify concrete issues with `file:line` specifics: duplication, complexity, dead code, poor naming, missing abstractions.
+- Check the target's test coverage. If coverage is thin, flag it — a safety net (Step 3) may be warranted.
+
+## Step 2: Plan
+
+Present a concise plan:
+- What's wrong now — the smells worth fixing.
+- The incremental changes, in safe order (smallest behavior-preserving steps first).
+- Whether to write a test safety net first (recommend it when coverage is thin and the code is non-trivial).
+- What will prove behavior is preserved — which tests.
+
+Ask via `AskUserQuestion`: "Proceed?" → **Proceed** / **Revise** (loop) / **Cancel**. Never edit before approval.
+
+## Step 3: Safety net (optional)
+
+If the plan calls for it, write characterization tests for the **current** behavior first and confirm they pass against the unmodified code. This is your regression guard.
+
+## Step 4: Implement
+
+Apply the refactor incrementally in this session. Preserve public APIs unless a breaking change was explicitly approved. **No feature changes — refactor only.** Keep context warm; no task files, no sub-agents.
+
+## Step 5: Verify
+
+- Run the build/lint command. Skip if none.
+- Run the full test suite. All previously-passing tests **must** still pass — that is the success criterion.
+- If anything regresses: report it and ask whether to fix, proceed, or revert (`git restore` / `git checkout --`).
+
+## Step 6: Commit (optional)
+
+Ask: "Commit these changes?"
+- **No** → Step 7.
+- **Yes**: if on `main`/`master`, branch to `refactor/<3-5-word-slug>` first; `git add -A && git commit -m "refactor: <summary>"`; then optionally push + open a PR (`git push -u origin <branch>` + `gh pr create`, or print the manual command).
+
+## Step 7: Review handoff
+
+End with `AskUserQuestion`: "Run an independent `/code-review` pass?"
+- **"Yes"** → invoke the `code-review` skill, scoped to the diff.
+- **"No"** → print "Done. Run `/code-review` when you want an independent pass." and stop.
+
+## Rules
+- Behavior preservation is the primary success criterion — a refactor that breaks tests is a failure.
+- One context, no fan-out. If you want to spawn implementers, the job is big enough for `/refactor`.
+- Never skip Step 2 approval before editing.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ A template for setting up Claude Code (agents, skills, memory) in any project. U
 |---|---|
 | [`/grill-me`, `/grill-with-docs`](#pre-build-grilling-grill-me-grill-with-docs) | Fuzzy idea → relentless interview → sharpened plan (run before `/build`) |
 | [`/build`](#the-build-pipeline-build) | PRD → plan → **plan review** → parallel implementation → code review |
+| [`/build-lite`](#lightweight-pipelines-build-lite-refactor-lite) | Feature → plan → approve → implement in one context — no fan-out, review separated |
 | [`/debug-workflow`](#the-debug-pipeline-debug-workflow) | Bug report → investigate → diagnose → TDD fix → review |
 | [`/refactor`](#the-refactor-pipeline-refactor) | Target → audit → (write tests) → refactor → behavior-preservation review |
+| [`/refactor-lite`](#lightweight-pipelines-build-lite-refactor-lite) | Target → audit → plan → approve → refactor in one context — no fan-out, review separated |
 | [`/qa`](#the-qa-pipeline-qa) | Running app → exploratory browser testing → QA report + Playwright E2E tests |
 | [`/craft-pr`](#craft-a-pr-craft-pr) | Branch's task files + diff → polished PR description |
 
@@ -225,13 +227,15 @@ Review `.claude/settings.local.json` to adjust permissions for your project.
 │   └── test-writer.md                    # Writes missing tests for existing code
 ├── skills/                           # User-invocable skills (slash commands)
 │   ├── build/SKILL.md                    # /build — plan → review-plan → implement → review
+│   ├── build-lite/SKILL.md               # /build-lite — plan → approve → implement in one context (no fan-out)
 │   ├── craft-pr/SKILL.md                 # /craft-pr — generates PR description from tasks + diff
 │   ├── debug-workflow/SKILL.md           # /debug-workflow — investigate → diagnose → TDD fix → review
 │   ├── grill-me/SKILL.md                 # /grill-me — pre-PRD interview to align on a fuzzy plan
 │   ├── grill-with-docs/                  # /grill-with-docs — grill + update CONTEXT.md/ADRs inline
 │   ├── init-claude-setup/SKILL.md        # /init-claude-setup — project-level init (gitignore, settings)
 │   ├── qa/SKILL.md                       # /qa — exploratory QA via browser + Playwright E2E tests
-│   └── refactor/SKILL.md                 # /refactor — audit → plan → (tests) → implement → review
+│   ├── refactor/SKILL.md                 # /refactor — audit → plan → (tests) → implement → review
+│   └── refactor-lite/SKILL.md            # /refactor-lite — audit → approve → refactor in one context (no fan-out)
 ├── agent-memory/                     # Persistent memory per agent (survives across sessions)
 └── settings.local.json               # Local Claude Code settings
 
@@ -455,6 +459,28 @@ Once work is done on a branch, `/craft-pr` reads `tasks/<branch>/*.md` plus the 
 ```bash
 /craft-pr
 ```
+
+## Lightweight Pipelines (`/build-lite`, `/refactor-lite`)
+
+The heavy `/build` and `/refactor` pipelines spend tokens to buy **parallelism** and **context isolation**: a planner agent, a fan-out of implementer sub-agents, and a reviewer agent, each spawning cold and re-reading the same files, with task files serialized between them. That trade pays off for large, parallelizable work — and not much else.
+
+For everyday features and cleanups, `/build-lite` and `/refactor-lite` do the same job in a **single warm context**:
+
+```
+explore (read-only) → plan → you approve → implement → verify build+tests → optional commit → offer /code-review
+```
+
+No sub-agent fan-out, no intermediate task files, no orchestration-mode/worktree/brainstorm prompts. Because nothing re-reads the codebase from a cold context, they typically cost **fewer tokens** than the full pipelines, not just less ceremony. Code review is deliberately **separated** — they finish by offering an independent [`/code-review`](https://docs.claude.com/en/docs/claude-code) pass rather than bundling it, so the reviewer sees the diff with fresh eyes.
+
+**Reach for the lite version by default.** Use the heavy `/build` / `/refactor` only when the work spans many independent files worth implementing in parallel, or genuinely exceeds a single context (large migrations, broad sweeps).
+
+| | Heavy (`/build`, `/refactor`) | Lite (`/build-lite`, `/refactor-lite`) |
+|---|---|---|
+| Implementation | Parallel sub-agent fan-out | Single warm context |
+| Planning | `prd-task-planner` agent + task files | Inline plan, approved in chat |
+| Review | Bundled `code-reviewer` agent | Separated — offers `/code-review` |
+| Git plumbing | Auto-commit / branch / PR / worktree opt-ins | Optional commit (+ optional push/PR) |
+| Best for | Large, parallelizable work | Everyday features & cleanups |
 
 ## Agent Memory
 

--- a/setup.sh
+++ b/setup.sh
@@ -183,6 +183,7 @@ CLAUDE_FILES=(
   ".claude/agents/tdd-mode.md"
   ".claude/agents/test-writer.md"
   ".claude/skills/build/SKILL.md"
+  ".claude/skills/build-lite/SKILL.md"
   ".claude/skills/craft-pr/SKILL.md"
   ".claude/skills/debug-workflow/SKILL.md"
   ".claude/skills/grill-me/SKILL.md"
@@ -192,6 +193,7 @@ CLAUDE_FILES=(
   ".claude/skills/init-claude-setup/SKILL.md"
   ".claude/skills/qa/SKILL.md"
   ".claude/skills/refactor/SKILL.md"
+  ".claude/skills/refactor-lite/SKILL.md"
   ".claude/hooks/token-reducer-nudge.sh"
   ".claude/statusline.sh"
 )


### PR DESCRIPTION
## Summary

Adds two single-context alternatives to the heavy `/build` and `/refactor` pipelines, prompted by the move to Opus 4.8 — which can comfortably one-shot most everyday work that previously justified multi-agent fan-out.

Both follow the same flow in **one warm context**, with no sub-agent fan-out and no intermediate task files:

```
explore (read-only) → plan → you approve → implement → verify build+tests → optional commit → offer /code-review
```

Because nothing re-reads the codebase from a cold sub-agent context, these typically cost **fewer tokens** than the orchestrated pipelines, not just less ceremony.

## What's different from `/build` and `/refactor`

| | Heavy | Lite |
|---|---|---|
| Implementation | Parallel sub-agent fan-out | Single warm context |
| Planning | `prd-task-planner` agent + task files | Inline plan, approved in chat |
| Review | Bundled `code-reviewer` agent | **Separated** — offers `/code-review` |
| Git plumbing | Auto-commit / branch / PR / worktree opt-ins | Optional commit (+ optional push/PR) |
| Best for | Large, parallelizable work | Everyday features & cleanups |

`/refactor-lite` keeps the refactor-specific guarantees: behavior preservation as the success criterion, an optional characterization-test safety net before touching code, and API preservation.

**Guidance baked into the skill descriptions:** reach for lite by default; use the heavy pipelines only when the work needs real parallel fan-out or genuinely exceeds one context.

## Changes
- `.claude/skills/build-lite/SKILL.md` — new
- `.claude/skills/refactor-lite/SKILL.md` — new
- `setup.sh` — register both in `CLAUDE_FILES` so they install
- `README.md` — skill table, directory tree, and a new "Lightweight Pipelines" section with a heavy-vs-lite comparison

## Review Notes
The heavy `/build` and `/refactor` skills are untouched — this is purely additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/build-lite` and `/refactor-lite` lightweight pipeline variants with single-context workflows and separated code review.

* **Documentation**
  * Added comprehensive documentation for lightweight pipelines, including workflow descriptions and comparison with standard variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nickmaglowsch/claude-setup/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->